### PR TITLE
Fix webkit css property name

### DIFF
--- a/web-data/css/css-schema.xml
+++ b/web-data/css/css-schema.xml
@@ -504,7 +504,7 @@
 		<entry name="::-webkit-meter-bar" version="3.0" browsers="E13,C,O15,S6" />
 		<entry name="::-webkit-meter-even-less-good-value" version="3.0" browsers="E13,C,O15,S6" />
 		<entry name="::-webkit-meter-optimum-value" version="3.0" browsers="E13,C,O15,S6" />
-		<entry name="::-webkit-meter-suboptimal-value" version="3.0" browsers="E13,C,O15,S6" />
+		<entry name="::-webkit-meter-suboptimum-value" version="3.0" browsers="E13,C,O15,S6" />
 		<entry name="::-webkit-outer-spin-button" version="3.0" browsers="C,O,S6" />
 		<entry name="::-webkit-progress-bar" version="3.0" browsers="C,S3" />
 		<entry name="::-webkit-progress-inner-element" version="3.0" browsers="C,S3" />

--- a/web-data/data/browsers.css-data.json
+++ b/web-data/data/browsers.css-data.json
@@ -421,7 +421,7 @@
           "url": "https://developer.mozilla.org/docs/Web/CSS/color"
         }
       ],
-      "description": "Color of an element's text",
+      "description": "Sets the color of an element's text",
       "restrictions": [
         "color"
       ]
@@ -526,7 +526,7 @@
     },
     {
       "name": "opacity",
-      "syntax": "<number>",
+      "syntax": "<alpha-value>",
       "references": [
         {
           "name": "MDN Reference",
@@ -849,7 +849,7 @@
           "description": "Produces a wavy line."
         }
       ],
-      "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'>",
+      "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'> || <'text-decoration-thickness'>",
       "references": [
         {
           "name": "MDN Reference",
@@ -1436,7 +1436,7 @@
           "description": "Sets 'white-space-collapsing' to 'preserve' and 'text-wrap' to 'normal'."
         }
       ],
-      "syntax": "normal | pre | nowrap | pre-wrap | pre-line",
+      "syntax": "normal | pre | nowrap | pre-wrap | pre-line | break-spaces",
       "references": [
         {
           "name": "MDN Reference",
@@ -4650,7 +4650,7 @@
           "description": "Represents a repeated fragment of the track list, allowing a large number of columns or rows that exhibit a recurring pattern to be written in a more compact form."
         }
       ],
-      "syntax": "none | <track-list> | <auto-track-list>",
+      "syntax": "none | <track-list> | <auto-track-list> | subgrid <line-name-list>?",
       "references": [
         {
           "name": "MDN Reference",
@@ -4781,7 +4781,7 @@
           "description": "The 'open-quote' and 'close-quote' values of the 'content' property produce no quotations marks, as if they were 'no-open-quote' and 'no-close-quote' respectively."
         }
       ],
-      "syntax": "none | [ <string> <string> ]+",
+      "syntax": "none | auto | [ <string> <string> ]+",
       "references": [
         {
           "name": "MDN Reference",
@@ -6066,7 +6066,7 @@
           "description": "Represents a repeated fragment of the track list, allowing a large number of columns or rows that exhibit a recurring pattern to be written in a more compact form."
         }
       ],
-      "syntax": "none | <track-list> | <auto-track-list>",
+      "syntax": "none | <track-list> | <auto-track-list> | subgrid <line-name-list>?",
       "references": [
         {
           "name": "MDN Reference",
@@ -6285,7 +6285,7 @@
         "FF32",
         "S8",
         "C41",
-        "O"
+        "O28"
       ],
       "values": [
         {
@@ -6342,7 +6342,7 @@
             "FF32",
             "S8",
             "C41",
-            "O"
+            "O28"
           ],
           "description": "Creates a color with the hue of the source color and the saturation and luminosity of the backdrop color."
         },
@@ -6352,7 +6352,7 @@
             "FF32",
             "S8",
             "C41",
-            "O"
+            "O28"
           ],
           "description": "Creates a color with the saturation of the source color and the hue and luminosity of the backdrop color."
         },
@@ -6362,7 +6362,7 @@
             "FF32",
             "S8",
             "C41",
-            "O"
+            "O28"
           ],
           "description": "Creates a color with the hue and saturation of the source color and the luminosity of the backdrop color."
         },
@@ -6372,7 +6372,7 @@
             "FF32",
             "S8",
             "C41",
-            "O"
+            "O28"
           ],
           "description": "Creates a color with the luminosity of the source color and the hue and saturation of the backdrop color."
         }
@@ -6615,7 +6615,7 @@
           "description": "Breaks CJK scripts using a more restrictive set of line-breaking rules than 'normal'."
         }
       ],
-      "syntax": "auto | loose | normal | strict",
+      "syntax": "auto | loose | normal | strict | anywhere",
       "references": [
         {
           "name": "MDN Reference",
@@ -7023,7 +7023,7 @@
           "description": "Each line of text is underlined."
         }
       ],
-      "syntax": "none | [ underline || overline || line-through || blink ]",
+      "syntax": "none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error",
       "references": [
         {
           "name": "MDN Reference",
@@ -8217,7 +8217,8 @@
       "browsers": [
         "E12",
         "C33",
-        "IE6"
+        "IE6",
+        "O20"
       ],
       "values": [
         {
@@ -8453,7 +8454,7 @@
         "C37",
         "O24"
       ],
-      "syntax": "<number>",
+      "syntax": "<alpha-value>",
       "references": [
         {
           "name": "MDN Reference",
@@ -8984,7 +8985,8 @@
       "name": "scroll-snap-stop",
       "syntax": "normal | always",
       "browsers": [
-        "C75"
+        "C75",
+        "O62"
       ],
       "references": [
         {
@@ -9447,7 +9449,8 @@
       "browsers": [
         "E17",
         "FF62",
-        "S11"
+        "S11",
+        "C79"
       ],
       "references": [
         {
@@ -9531,6 +9534,7 @@
       "status": "experimental",
       "syntax": "[ <'offset-position'>? [ <'offset-path'> [ <'offset-distance'> || <'offset-rotate'> ]? ]? ]! [ / <'offset-anchor'> ]?",
       "browsers": [
+        "FF71",
         "C55",
         "O42"
       ],
@@ -9637,7 +9641,8 @@
       "syntax": "<'margin-left'>{1,2}",
       "browsers": [
         "FF66",
-        "C69"
+        "C69",
+        "O56"
       ],
       "references": [
         {
@@ -9652,7 +9657,8 @@
       "syntax": "<'padding-left'>{1,2}",
       "browsers": [
         "FF66",
-        "C69"
+        "C69",
+        "O56"
       ],
       "references": [
         {
@@ -9667,7 +9673,8 @@
       "syntax": "<'padding-left'>{1,2}",
       "browsers": [
         "FF66",
-        "C69"
+        "C69",
+        "O56"
       ],
       "references": [
         {
@@ -9681,8 +9688,8 @@
       "name": "font-size-adjust",
       "browsers": [
         "FF40",
-        "C43",
-        "O30"
+        "C54",
+        "O41"
       ],
       "values": [
         {
@@ -9899,6 +9906,16 @@
       "name": "offset-anchor",
       "status": "experimental",
       "syntax": "auto | <position>",
+      "browsers": [
+        "FF70",
+        "C79"
+      ],
+      "references": [
+        {
+          "name": "MDN Reference",
+          "url": "https://developer.mozilla.org/docs/Web/CSS/offset-anchor"
+        }
+      ],
       "description": "Defines an anchor point of the box positioned along the path. The anchor point specifies the point of the box which is to be considered as the point that is moved along the path."
     },
     {
@@ -9912,7 +9929,8 @@
       "syntax": "<'margin-left'>{1,2}",
       "browsers": [
         "FF66",
-        "C69"
+        "C69",
+        "O56"
       ],
       "references": [
         {
@@ -10603,7 +10621,7 @@
         "FF53",
         "S4",
         "C1",
-        "O"
+        "O15"
       ],
       "values": [
         {
@@ -17729,6 +17747,12 @@
       "description": "Changes the appearance of buttons and other controls to resemble native controls."
     },
     {
+      "name": "aspect-ratio",
+      "status": "experimental",
+      "syntax": "auto | <ratio>",
+      "description": ""
+    },
+    {
       "name": "azimuth",
       "status": "obsolete",
       "syntax": "<angle> | [ [ left-side | far-left | left | center-left | center | center-right | right | far-right | right-side ] || behind ] | leftwards | rightwards",
@@ -18466,6 +18490,21 @@
       "description": "The scroll-snap-type-y CSS property defines how strictly snap points are enforced on the vertical axis of the scroll container in case there is one.\n\nSpecifying any precise animations or physics used to enforce those snap points is not covered by this property but instead left up to the user agent."
     },
     {
+      "name": "text-decoration-thickness",
+      "syntax": "auto | from-font | <length>",
+      "browsers": [
+        "FF70",
+        "S12.1"
+      ],
+      "references": [
+        {
+          "name": "MDN Reference",
+          "url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-thickness"
+        }
+      ],
+      "description": "The text-decoration-thickness CSS property sets the thickness, or width, of the decoration line that is used on text in an element, such as a line-through, underline, or overline."
+    },
+    {
       "name": "text-emphasis",
       "syntax": "<'text-emphasis-style'> || <'text-emphasis-color'>",
       "browsers": [
@@ -18532,6 +18571,21 @@
         }
       ],
       "description": "The text-emphasis-style CSS property defines the type of emphasis used. It can also be set, and reset, using the text-emphasis shorthand."
+    },
+    {
+      "name": "text-underline-offset",
+      "syntax": "auto | from-font | <length>",
+      "browsers": [
+        "FF70",
+        "S12.1"
+      ],
+      "references": [
+        {
+          "name": "MDN Reference",
+          "url": "https://developer.mozilla.org/docs/Web/CSS/text-underline-offset"
+        }
+      ],
+      "description": "The text-underline-offset CSS property sets the offset distance of an underline text decoration line (applied using text-decoration) from its original position."
     },
     {
       "name": "speak-as",
@@ -19573,7 +19627,8 @@
       "status": "experimental",
       "browsers": [
         "FF4",
-        "C67"
+        "C67",
+        "O54"
       ],
       "references": [
         {
@@ -19669,7 +19724,8 @@
         "E12",
         "FF47",
         "C37",
-        "IE11"
+        "IE11",
+        "O24"
       ],
       "references": [
         {
@@ -20074,12 +20130,17 @@
       ]
     },
     {
-      "name": "::-webkit-meter-suboptimal-value",
+      "name": "::-webkit-meter-suboptimum-value",
       "browsers": [
-        "E13",
-        "C",
-        "O15",
-        "S6"
+        "S5.1",
+        "C12",
+        "O15"
+      ],
+      "references": [
+        {
+          "name": "MDN Reference",
+          "url": "https://developer.mozilla.org/docs/Web/CSS/::-webkit-meter-suboptimum-value"
+        }
       ]
     },
     {
@@ -20410,7 +20471,8 @@
     {
       "name": "::marker",
       "browsers": [
-        "FF68"
+        "FF68",
+        "C80"
       ],
       "references": [
         {


### PR DESCRIPTION
::-webkit-meter-suboptimum-value and not ::-webkit-meter-suboptimal-value
https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-meter-suboptimum-value

Not sure if the matching browsers.css-data.json file has to be updated as well?