### PR TITLE
Add values for aria-haspopup

### DIFF
--- a/web-data/data/browsers.css-data.json
+++ b/web-data/data/browsers.css-data.json
@@ -155,13 +155,6 @@
     },
     {
       "name": "justify-self",
-      "browsers": [
-        "E16",
-        "FF45",
-        "S10.1",
-        "C57",
-        "O44"
-      ],
       "values": [
         {
           "name": "auto"
@@ -5510,13 +5503,6 @@
     },
     {
       "name": "grid-template-columns",
-      "browsers": [
-        "E16",
-        "FF52",
-        "S10.1",
-        "C57",
-        "O44"
-      ],
       "values": [
         {
           "name": "none",
@@ -5565,13 +5551,6 @@
     },
     {
       "name": "grid-template-rows",
-      "browsers": [
-        "E16",
-        "FF52",
-        "S10.1",
-        "C57",
-        "O44"
-      ],
       "values": [
         {
           "name": "none",
@@ -6851,7 +6830,7 @@
       "browsers": [
         "E79",
         "FF41",
-        "S10.1",
+        "S12.1",
         "C57",
         "O44"
       ],
@@ -9185,7 +9164,7 @@
     {
       "name": "-ms-grid-columns",
       "browsers": [
-        "E12",
+        "E",
         "IE10"
       ],
       "relevance": 50,
@@ -9273,7 +9252,7 @@
     {
       "name": "-ms-grid-rows",
       "browsers": [
-        "E12",
+        "E",
         "IE10"
       ],
       "relevance": 50,
@@ -12759,6 +12738,7 @@
       "browsers": [
         "E79",
         "FF36",
+        "S14",
         "C61",
         "O48"
       ],
@@ -13665,7 +13645,7 @@
       "browsers": [
         "E79",
         "FF41",
-        "S5.1",
+        "S14",
         "C48",
         "O15"
       ],
@@ -13675,7 +13655,7 @@
           "browsers": [
             "E79",
             "FF41",
-            "S5.1",
+            "S14",
             "C48",
             "O15"
           ],
@@ -13686,7 +13666,7 @@
           "browsers": [
             "E79",
             "FF41",
-            "S5.1",
+            "S14",
             "C48",
             "O15"
           ],
@@ -17543,7 +17523,7 @@
       "relevance": 60,
       "browsers": [
         "E84",
-        "FF1",
+        "FF80",
         "S3",
         "C84",
         "O70"
@@ -17990,7 +17970,10 @@
       "syntax": "[ <custom-ident> <integer>? ]+ | none",
       "relevance": 50,
       "browsers": [
-        "FF68"
+        "E85",
+        "FF68",
+        "C85",
+        "O71"
       ],
       "references": [
         {
@@ -18774,7 +18757,7 @@
       "browsers": [
         "E84",
         "FF63",
-        "S10.1",
+        "S12.1",
         "C84",
         "O70"
       ],
@@ -21422,10 +21405,10 @@
     {
       "name": "::marker",
       "browsers": [
-        "E80",
+        "E86",
         "FF68",
         "S11.1",
-        "C80"
+        "C86"
       ],
       "references": [
         {

--- a/web-data/data/browsers.html-data.json
+++ b/web-data/data/browsers.html-data.json
@@ -4360,7 +4360,7 @@
     },
     {
       "name": "aria-haspopup",
-      "valueSet": "b",
+      "valueSet": "haspopup",
       "references": [
         {
           "name": "WAI-ARIA Reference",
@@ -5902,6 +5902,60 @@
         },
         {
           "name": "viewport"
+        }
+      ]
+    },
+    {
+      "name": "haspopup",
+      "values": [
+        {
+          "name": "false",
+          "description": {
+            "kind": "markdown",
+            "value": "(default) Indicates the element does not have a popup."
+          }
+        },
+        {
+          "name": "true",
+          "description": {
+            "kind": "markdown",
+            "value": "Indicates the popup is a menu."
+          }
+        },
+        {
+          "name": "menu",
+          "description": {
+            "kind": "markdown",
+            "value": "Indicates the popup is a menu."
+          }
+        },
+        {
+          "name": "listbox",
+          "description": {
+            "kind": "markdown",
+            "value": "Indicates the popup is a listbox."
+          }
+        },
+        {
+          "name": "tree",
+          "description": {
+            "kind": "markdown",
+            "value": "Indicates the popup is a tree."
+          }
+        },
+        {
+          "name": "grid",
+          "description": {
+            "kind": "markdown",
+            "value": "Indicates the popup is a grid."
+          }
+        },
+        {
+          "name": "dialog",
+          "description": {
+            "kind": "markdown",
+            "value": "Indicates the popup is a dialog."
+          }
         }
       ]
     }

--- a/web-data/html/ariaData.json
+++ b/web-data/html/ariaData.json
@@ -64,7 +64,7 @@
   },
   {
     "name": "aria-haspopup",
-    "valueSet": "b"
+    "valueSet": "haspopup"
   },
   {
     "name": "aria-hidden",

--- a/web-data/html/valueSets.json
+++ b/web-data/html/valueSets.json
@@ -1129,5 +1129,59 @@
         "name": "viewport"
       }
     ]
+  },
+  {
+    "name": "haspopup",
+    "values": [
+      {
+        "name": "false",
+        "description": {
+          "kind": "markdown",
+          "value": "(default) Indicates the element does not have a popup."
+        }
+      },
+      {
+        "name": "true",
+        "description": {
+          "kind": "markdown",
+          "value": "Indicates the popup is a menu."
+        }
+      },
+      {
+        "name": "menu",
+        "description": {
+          "kind": "markdown",
+          "value": "Indicates the popup is a menu."
+        }
+      },
+      {
+        "name": "listbox",
+        "description": {
+          "kind": "markdown",
+          "value": "Indicates the popup is a listbox."
+        }
+      },
+      {
+        "name": "tree",
+        "description": {
+          "kind": "markdown",
+          "value": "Indicates the popup is a tree."
+        }
+      },
+      {
+        "name": "grid",
+        "description": {
+          "kind": "markdown",
+          "value": "Indicates the popup is a grid."
+        }
+      },
+      {
+        "name": "dialog",
+        "description": {
+          "kind": "markdown",
+          "value": "Indicates the popup is a dialog."
+        }
+      }
+    ]
   }
 ]

--- a/web-data/package.json
+++ b/web-data/package.json
@@ -9,7 +9,7 @@
     "data/*"
   ],
   "devDependencies": {
-    "mdn-browser-compat-data": "^1.0.34",
+    "mdn-browser-compat-data": "^1.0.40",
     "mdn-data": "^2.0.11",
     "xml2js": "^0.4.22"
   }

--- a/web-data/yarn.lock
+++ b/web-data/yarn.lock
@@ -80,10 +80,10 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.0"
 
-mdn-browser-compat-data@^1.0.34:
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/mdn-browser-compat-data/-/mdn-browser-compat-data-1.0.34.tgz#6c62df103ebefb68207098f90aaf7d840028d21c"
-  integrity sha512-bIufENDguhcjV4qAguNEyEBoYuRgS7vIwSNifYt8s3FIBrsRwUd0xWah0P7H1lLIcBCPwwwQWpLgWHx3K7rFFg==
+mdn-browser-compat-data@^1.0.40:
+  version "1.0.40"
+  resolved "https://registry.yarnpkg.com/mdn-browser-compat-data/-/mdn-browser-compat-data-1.0.40.tgz#6e8f6e1dd2d8cf880ebea94cf66cfe000a16603b"
+  integrity sha512-yjM/OG0krZIgi+XrhJWS3CJ9UQuGM4FfjIUIt2f65er6qczkM+WjtNEv/9ZF9DxDs/2GR3SO6hDaZLplTRrrfw==
   dependencies:
     extend "3.0.2"
 


### PR DESCRIPTION
The [aria-haspop](https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup) attribute can have values other than "true" or "false". This change adds the additional values. 

Not sure if I did this right. First I edited `ariaData.json` and `valuesSets.json` by hand. Then I added ran `yarn generate-data`. 