### PR TITLE
Fix typo in browsers.css-data.json

### DIFF
--- a/web-data/data/browsers.css-data.json
+++ b/web-data/data/browsers.css-data.json
@@ -12245,7 +12245,7 @@
         },
         {
           "name": "visible",
-          "description": "The given element can be the target element for pointer events when the ‘visibility’ property is set to visible and the pointer is over either the interior or the perimete of the element."
+          "description": "The given element can be the target element for pointer events when the ‘visibility’ property is set to visible and the pointer is over either the interior or the perimeter of the element."
         },
         {
           "name": "visibleFill",


### PR DESCRIPTION
Noticed this typo in a popover for the description of `pointer-events: visible;`

|Before|After|
|---|---|
|the interior or the **_perimete_** of the element.|the interior or the **_perimeter_** of the element.|