### PR TITLE
Added system-ui to the system font stack

### DIFF
--- a/web-data/css/css-schema.xml
+++ b/web-data/css/css-schema.xml
@@ -2536,7 +2536,7 @@
 		<entry name="font-family" restriction="font" version="1.0" browsers="all" ref="http://www.w3.org/TR/css3-fonts/#font-family0" syntax="body { $(name): arial, verdana; }">
 			<desc>Specifies a prioritized list of font family names or generic family names. A user agent iterates through the list of family names until it matches an available font that contains a glyph for the character to be rendered.</desc>
 			<values>
-				<value name="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif" version="1.0" browsers="all" />
+				<value name="system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif" version="1.0" browsers="all" />
 				<value name="Arial, Helvetica, sans-serif" version="1.0" browsers="all" />
 				<value name="Cambria, Cochin, Georgia, Times, 'Times New Roman', serif" version="1.0" browsers="all" />
 				<value name="'Courier New', Courier, monospace" version="1.0" browsers="all" />


### PR DESCRIPTION
A web developer on Twitter [pointed out](https://twitter.com/mrleblanc101/status/1477041722282631168) the snippet for system fonts is outdated.

Chrome and Safari have the [system-ui](https://caniuse.com/font-family-system-ui) keyword, a more modern way of writing “-apple-system, BlinkMacSystemFont". It was added to Chrome in 2016 and Safari in 2017 and has ~96% support according to CIU.