### PR TITLE
Add loading/eager/lazy descriptions

### DIFF
--- a/web-data/data/browsers.html-data.json
+++ b/web-data/data/browsers.html-data.json
@@ -1545,7 +1545,11 @@
         },
         {
           "name": "loading",
-          "valueSet": "loading"
+          "valueSet": "loading",
+          "description": {
+            "kind": "markdown",
+            "value": "Indicates how the browser should load the image."
+          }
         },
         {
           "name": "referrerpolicy",
@@ -6089,10 +6093,18 @@
       "name": "loading",
       "values": [
         {
-          "name": "eager"
+          "name": "eager",
+          "description": {
+            "kind": "markdown",
+            "value": "Loads the image immediately, regardless of whether or not the image is currently within the visible viewport (this is the default value)."
+          }
         },
         {
-          "name": "lazy"
+          "name": "lazy",
+          "description": {
+            "kind": "markdown",
+            "value": "Defers loading the image until it reaches a calculated distance from the viewport, as defined by the browser. The intent is to avoid the network and storage bandwidth needed to handle the image until it's reasonably certain that it will be needed. This generally improves the performance of the content in most typical use cases."
+          }
         }
       ]
     },

--- a/web-data/html/htmlTags.json
+++ b/web-data/html/htmlTags.json
@@ -537,7 +537,11 @@
       },
       {
         "name": "loading",
-        "valueSet": "loading"
+        "valueSet": "loading",
+        "description": {
+          "kind": "markdown",
+          "value": "Indicates how the browser should load the image."
+        }
       },
       {
         "name": "referrerpolicy",

--- a/web-data/html/valueSets.json
+++ b/web-data/html/valueSets.json
@@ -1225,10 +1225,18 @@
     "name": "loading",
     "values": [
       {
-        "name": "eager"
+        "name": "eager",
+        "description": {
+          "kind": "markdown",
+          "value": "Loads the image immediately, regardless of whether or not the image is currently within the visible viewport (this is the default value)."
+        }
       },
       {
-        "name": "lazy"
+        "name": "lazy",
+        "description": {
+          "kind": "markdown",
+          "value": "Defers loading the image until it reaches a calculated distance from the viewport, as defined by the browser. The intent is to avoid the network and storage bandwidth needed to handle the image until it's reasonably certain that it will be needed. This generally improves the performance of the content in most typical use cases."
+        }
       }
     ]
   },


### PR DESCRIPTION
I intend on adding HTML attribute/tag completion to Shopify Liquid HTML templates by using this repo's data.

I noticed that the img#loading data was lacking a description. The loading ValueSet did as well.

This PR adds the description for this attribute and value set as per what's on MDN at the time of making this PR.

[MDN reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#:~:text=a%20fallback%20destination.-,loading,improves%20the%20performance%20of%20the%20content%20in%20most%20typical%20use%20cases.,-Note%3A%20Loading)

Submission containing materials of a third party: Docs from MDN which should be covered by the "reference."