### PR TITLE
Adds baseline status to html elements and attributes

### DIFF
--- a/web-data/css/mdn/mdn-browser-compat-data-importer.mjs
+++ b/web-data/css/mdn/mdn-browser-compat-data-importer.mjs
@@ -150,7 +150,7 @@ function toCompatString(bcdProperty) {
   return s.join(',');
 }
 
-function supportToShortCompatString(support, browserAbbrev) {
+export function supportToShortCompatString(support, browserAbbrev) {
   let version_added;
   if (Array.isArray(support) && support[0] && support[0].version_added) {
     version_added = support[0].version_added;

--- a/web-data/data/browsers.html-data.json
+++ b/web-data/data/browsers.html-data.json
@@ -17,11 +17,37 @@
         },
         {
           "name": "version",
-          "description": "Specifies the version of the HTML [Document Type Definition](https://developer.mozilla.org/en-US/docs/Glossary/DTD \"Document Type Definition: In HTML, the doctype is the required \"<!DOCTYPE html>\" preamble found at the top of all documents. Its sole purpose is to prevent a browser from switching into so-called “quirks mode” when rendering a document; that is, the \"<!DOCTYPE html>\" doctype ensures that the browser makes a best-effort attempt at following the relevant specifications, rather than using a different rendering mode that is incompatible with some specifications.\") that governs the current document. This attribute is not needed, because it is redundant with the version information in the document type declaration."
+          "description": "Specifies the version of the HTML [Document Type Definition](https://developer.mozilla.org/en-US/docs/Glossary/DTD \"Document Type Definition: In HTML, the doctype is the required \"<!DOCTYPE html>\" preamble found at the top of all documents. Its sole purpose is to prevent a browser from switching into so-called “quirks mode” when rendering a document; that is, the \"<!DOCTYPE html>\" doctype ensures that the browser makes a best-effort attempt at following the relevant specifications, rather than using a different rendering mode that is incompatible with some specifications.\") that governs the current document. This attribute is not needed, because it is redundant with the version information in the document type declaration.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "xmlns",
-          "description": "Specifies the XML Namespace of the document. Default value is `\"http://www.w3.org/1999/xhtml\"`. This is required in documents parsed with XML parsers, and optional in text/html documents."
+          "description": "Specifies the XML Namespace of the document. Default value is `\"http://www.w3.org/1999/xhtml\"`. This is required in documents parsed with XML parsers, and optional in text/html documents.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         }
       ],
       "references": [
@@ -29,7 +55,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/html"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "head",
@@ -40,7 +80,11 @@
       "attributes": [
         {
           "name": "profile",
-          "description": "The URIs of one or more metadata profiles, separated by white space."
+          "description": "The URIs of one or more metadata profiles, separated by white space.",
+          "browsers": [],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -48,7 +92,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/head"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "title",
@@ -62,7 +120,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/title"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "base",
@@ -77,6 +149,20 @@
           "description": {
             "kind": "markdown",
             "value": "The base URL to be used throughout the document for relative URL addresses. If this attribute is specified, this element must come before any other elements with attributes whose values are URLs. Absolute and relative URLs are allowed."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -85,6 +171,20 @@
           "description": {
             "kind": "markdown",
             "value": "A name or keyword indicating the default location to display the result when hyperlinks or forms cause navigation, for elements that do not have an explicit target reference. It is a name of, or keyword for, a _browsing context_ (for example: tab, window, or inline frame). The following keywords have special meanings:\n\n*   `_self`: Load the result into the same browsing context as the current one. This value is the default if the attribute is not specified.\n*   `_blank`: Load the result into a new unnamed browsing context.\n*   `_parent`: Load the result into the parent browsing context of the current one. If there is no parent, this option behaves the same way as `_self`.\n*   `_top`: Load the result into the top-level browsing context (that is, the browsing context that is an ancestor of the current one, and has no parent). If there is no parent, this option behaves the same way as `_self`.\n\nIf this attribute is specified, this element must come before any other elements with attributes whose values are URLs."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         }
       ],
@@ -93,7 +193,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/base"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S3",
+        "SM2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "link",
@@ -108,6 +222,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute specifies the [URL](https://developer.mozilla.org/en-US/docs/Glossary/URL \"URL: Uniform Resource Locator (URL) is a text string specifying where a resource can be found on the Internet.\") of the linked resource. A URL can be absolute or relative."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -116,6 +244,20 @@
           "description": {
             "kind": "markdown",
             "value": "This enumerated attribute indicates whether [CORS](https://developer.mozilla.org/en-US/docs/Glossary/CORS \"CORS: CORS (Cross-Origin Resource Sharing) is a system, consisting of transmitting HTTP headers, that determines whether browsers block frontend JavaScript code from accessing responses for cross-origin requests.\") must be used when fetching the resource. [CORS-enabled images](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_Enabled_Image) can be reused in the [`<canvas>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas \"Use the HTML <canvas> element with either the canvas scripting API or the WebGL API to draw graphics and animations.\") element without being _tainted_. The allowed values are:\n\n`anonymous`\n\nA cross-origin request (i.e. with an [`Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin \"The Origin request header indicates where a fetch originates from. It doesn't include any path information, but only the server name. It is sent with CORS requests, as well as with POST requests. It is similar to the Referer header, but, unlike this header, it doesn't disclose the whole path.\") HTTP header) is performed, but no credential is sent (i.e. no cookie, X.509 certificate, or HTTP Basic authentication). If the server does not give credentials to the origin site (by not setting the [`Access-Control-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin \"The Access-Control-Allow-Origin response header indicates whether the response can be shared with requesting code from the given origin.\") HTTP header) the image will be tainted and its usage restricted.\n\n`use-credentials`\n\nA cross-origin request (i.e. with an `Origin` HTTP header) is performed along with a credential sent (i.e. a cookie, certificate, and/or HTTP Basic authentication is performed). If the server does not give credentials to the origin site (through [`Access-Control-Allow-Credentials`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials \"The Access-Control-Allow-Credentials response header tells browsers whether to expose the response to frontend JavaScript code when the request's credentials mode (Request.credentials) is \"include\".\") HTTP header), the resource will be _tainted_ and its usage restricted.\n\nIf the attribute is not present, the resource is fetched without a [CORS](https://developer.mozilla.org/en-US/docs/Glossary/CORS \"CORS: CORS (Cross-Origin Resource Sharing) is a system, consisting of transmitting HTTP headers, that determines whether browsers block frontend JavaScript code from accessing responses for cross-origin requests.\") request (i.e. without sending the `Origin` HTTP header), preventing its non-tainted usage. If invalid, it is handled as if the enumerated keyword **anonymous** was used. See [CORS settings attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for additional information."
+          },
+          "browsers": [
+            "C34",
+            "CA34",
+            "E17",
+            "FF18",
+            "FFA18",
+            "S10",
+            "SM10"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2018-04-30",
+            "baseline_high_date": "2020-10-30"
           }
         },
         {
@@ -123,6 +265,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute names a relationship of the linked document to the current document. The attribute must be a space-separated list of the [link types values](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types)."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -130,6 +286,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute specifies the media that the linked resource applies to. Its value must be a media type / [media query](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_queries). This attribute is mainly useful when linking to external stylesheets — it allows the user agent to pick the best adapted one for the device it runs on.\n\n**Notes:**\n\n*   In HTML 4, this can only be a simple white-space-separated list of media description literals, i.e., [media types and groups](https://developer.mozilla.org/en-US/docs/Web/CSS/@media), where defined and allowed as values for this attribute, such as `print`, `screen`, `aural`, `braille`. HTML5 extended this to any kind of [media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_queries), which are a superset of the allowed values of HTML 4.\n*   Browsers not supporting [CSS3 Media Queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_queries) won't necessarily recognize the adequate link; do not forget to set fallback links, the restricted set of media queries defined in HTML 4."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -137,6 +307,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute indicates the language of the linked resource. It is purely advisory. Allowed values are determined by [BCP47](https://www.ietf.org/rfc/bcp/bcp47.txt). Use this attribute only if the [`href`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href) attribute is present."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -144,6 +328,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute is used to define the type of the content linked to. The value of the attribute should be a MIME type such as **text/html**, **text/css**, and so on. The common use of this attribute is to define the type of stylesheet being referenced (such as **text/css**), but given that CSS is the only stylesheet language used on the web, not only is it possible to omit the `type` attribute, but is actually now recommended practice. It is also used on `rel=\"preload\"` link types, to make sure the browser only downloads file types that it supports."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -151,11 +349,39 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute defines the sizes of the icons for visual media contained in the resource. It must be present only if the [`rel`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-rel) contains a value of `icon` or a non-standard type such as Apple's `apple-touch-icon`. It may have the following values:\n\n*   `any`, meaning that the icon can be scaled to any size as it is in a vector format, like `image/svg+xml`.\n*   a white-space separated list of sizes, each in the format `_<width in pixels>_x_<height in pixels>_` or `_<width in pixels>_X_<height in pixels>_`. Each of these sizes must be contained in the resource.\n\n**Note:** Most icon formats are only able to store one single icon; therefore most of the time the [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-sizes) contains only one entry. MS's ICO format does, as well as Apple's ICNS. ICO is more ubiquitous; you should definitely use it."
+          },
+          "browsers": [
+            "C80",
+            "CA80",
+            "E80",
+            "FF72",
+            "FFA79",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "≤2020-07-28",
+            "baseline_high_date": "≤2023-01-28"
           }
         },
         {
           "name": "as",
-          "description": "This attribute is only used when `rel=\"preload\"` or `rel=\"prefetch\"` has been set on the `<link>` element. It specifies the type of content being loaded by the `<link>`, which is necessary for content prioritization, request matching, application of correct [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP), and setting of correct [`Accept`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept \"The Accept request HTTP header advertises which content types, expressed as MIME types, the client is able to understand. Using content negotiation, the server then selects one of the proposals, uses it and informs the client of its choice with the Content-Type response header. Browsers set adequate values for this header depending on the context where the request is done: when fetching a CSS stylesheet a different value is set for the request than when fetching an image, video or a script.\") request header."
+          "description": "This attribute is only used when `rel=\"preload\"` or `rel=\"prefetch\"` has been set on the `<link>` element. It specifies the type of content being loaded by the `<link>`, which is necessary for content prioritization, request matching, application of correct [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP), and setting of correct [`Accept`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept \"The Accept request HTTP header advertises which content types, expressed as MIME types, the client is able to understand. Using content negotiation, the server then selects one of the proposals, uses it and informs the client of its choice with the Content-Type response header. Browsers set adequate values for this header depending on the context where the request is done: when fetching a CSS stylesheet a different value is set for the request than when fetching an image, video or a script.\") request header.",
+          "browsers": [
+            "C50",
+            "CA50",
+            "E17",
+            "FF56",
+            "FFA56",
+            "S10",
+            "SM10"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2018-04-30",
+            "baseline_high_date": "2020-10-30"
+          }
         },
         {
           "name": "importance",
@@ -167,11 +393,39 @@
         },
         {
           "name": "integrity",
-          "description": "Contains inline metadata — a base64-encoded cryptographic hash of the resource (file) you’re telling the browser to fetch. The browser can use this to verify that the fetched resource has been delivered free of unexpected manipulation. See [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)."
+          "description": "Contains inline metadata — a base64-encoded cryptographic hash of the resource (file) you’re telling the browser to fetch. The browser can use this to verify that the fetched resource has been delivered free of unexpected manipulation. See [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity).",
+          "browsers": [
+            "C45",
+            "CA45",
+            "E17",
+            "FF43",
+            "FFA43",
+            "S11.1",
+            "SM11.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2018-04-30",
+            "baseline_high_date": "2020-10-30"
+          }
         },
         {
           "name": "referrerpolicy",
-          "description": "A string indicating which referrer to use when fetching the resource:\n\n*   `no-referrer` means that the [`Referer`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer \"The Referer request header contains the address of the previous web page from which a link to the currently requested page was followed. The Referer header allows servers to identify where people are visiting them from and may use that data for analytics, logging, or optimized caching, for example.\") header will not be sent.\n*   `no-referrer-when-downgrade` means that no [`Referer`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer \"The Referer request header contains the address of the previous web page from which a link to the currently requested page was followed. The Referer header allows servers to identify where people are visiting them from and may use that data for analytics, logging, or optimized caching, for example.\") header will be sent when navigating to an origin without TLS (HTTPS). This is a user agent’s default behavior, if no policy is otherwise specified.\n*   `origin` means that the referrer will be the origin of the page, which is roughly the scheme, the host, and the port.\n*   `origin-when-cross-origin` means that navigating to other origins will be limited to the scheme, the host, and the port, while navigating on the same origin will include the referrer's path.\n*   `unsafe-url` means that the referrer will include the origin and the path (but not the fragment, password, or username). This case is unsafe because it can leak origins and paths from TLS-protected resources to insecure origins."
+          "description": "A string indicating which referrer to use when fetching the resource:\n\n*   `no-referrer` means that the [`Referer`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer \"The Referer request header contains the address of the previous web page from which a link to the currently requested page was followed. The Referer header allows servers to identify where people are visiting them from and may use that data for analytics, logging, or optimized caching, for example.\") header will not be sent.\n*   `no-referrer-when-downgrade` means that no [`Referer`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer \"The Referer request header contains the address of the previous web page from which a link to the currently requested page was followed. The Referer header allows servers to identify where people are visiting them from and may use that data for analytics, logging, or optimized caching, for example.\") header will be sent when navigating to an origin without TLS (HTTPS). This is a user agent’s default behavior, if no policy is otherwise specified.\n*   `origin` means that the referrer will be the origin of the page, which is roughly the scheme, the host, and the port.\n*   `origin-when-cross-origin` means that navigating to other origins will be limited to the scheme, the host, and the port, while navigating on the same origin will include the referrer's path.\n*   `unsafe-url` means that the referrer will include the origin and the path (but not the fragment, password, or username). This case is unsafe because it can leak origins and paths from TLS-protected resources to insecure origins.",
+          "browsers": [
+            "C51",
+            "CA51",
+            "E79",
+            "FF50",
+            "FFA50",
+            "S14",
+            "SM14"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2020-09-16",
+            "baseline_high_date": "2023-03-16"
+          }
         },
         {
           "name": "title",
@@ -183,7 +437,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/link"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "meta",
@@ -198,6 +466,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute defines the name of a piece of document-level metadata. It should not be set if one of the attributes [`itemprop`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-itemprop), [`http-equiv`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-http-equiv) or [`charset`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-charset) is also set.\n\nThis metadata name is associated with the value contained by the [`content`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-content) attribute. The possible values for the name attribute are:\n\n*   `application-name` which defines the name of the application running in the web page.\n    \n    **Note:**\n    \n    *   Browsers may use this to identify the application. It is different from the [`<title>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title \"The HTML Title element (<title>) defines the document's title that is shown in a browser's title bar or a page's tab.\") element, which usually contain the application name, but may also contain information like the document name or a status.\n    *   Simple web pages shouldn't define an application-name.\n    \n*   `author` which defines the name of the document's author.\n*   `description` which contains a short and accurate summary of the content of the page. Several browsers, like Firefox and Opera, use this as the default description of bookmarked pages.\n*   `generator` which contains the identifier of the software that generated the page.\n*   `keywords` which contains words relevant to the page's content separated by commas.\n*   `referrer` which controls the [`Referer` HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer) attached to requests sent from the document:\n    \n    Values for the `content` attribute of `<meta name=\"referrer\">`\n    \n    `no-referrer`\n    \n    Do not send a HTTP `Referrer` header.\n    \n    `origin`\n    \n    Send the [origin](https://developer.mozilla.org/en-US/docs/Glossary/Origin) of the document.\n    \n    `no-referrer-when-downgrade`\n    \n    Send the [origin](https://developer.mozilla.org/en-US/docs/Glossary/Origin) as a referrer to URLs as secure as the current page, (https→https), but does not send a referrer to less secure URLs (https→http). This is the default behaviour.\n    \n    `origin-when-cross-origin`\n    \n    Send the full URL (stripped of parameters) for same-origin requests, but only send the [origin](https://developer.mozilla.org/en-US/docs/Glossary/Origin) for other cases.\n    \n    `same-origin`\n    \n    A referrer will be sent for [same-site origins](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy), but cross-origin requests will contain no referrer information.\n    \n    `strict-origin`\n    \n    Only send the origin of the document as the referrer to a-priori as-much-secure destination (HTTPS->HTTPS), but don't send it to a less secure destination (HTTPS->HTTP).\n    \n    `strict-origin-when-cross-origin`\n    \n    Send a full URL when performing a same-origin request, only send the origin of the document to a-priori as-much-secure destination (HTTPS->HTTPS), and send no header to a less secure destination (HTTPS->HTTP).\n    \n    `unsafe-URL`\n    \n    Send the full URL (stripped of parameters) for same-origin or cross-origin requests.\n    \n    **Notes:**\n    \n    *   Some browsers support the deprecated values of `always`, `default`, and `never` for referrer.\n    *   Dynamically inserting `<meta name=\"referrer\">` (with [`document.write`](https://developer.mozilla.org/en-US/docs/Web/API/Document/write) or [`appendChild`](https://developer.mozilla.org/en-US/docs/Web/API/Node/appendChild)) makes the referrer behaviour unpredictable.\n    *   When several conflicting policies are defined, the no-referrer policy is applied.\n    \n\nThis attribute may also have a value taken from the extended list defined on [WHATWG Wiki MetaExtensions page](https://wiki.whatwg.org/wiki/MetaExtensions). Although none have been formally accepted yet, a few commonly used names are:\n\n*   `creator` which defines the name of the creator of the document, such as an organization or institution. If there are more than one, several [`<meta>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta \"The HTML <meta> element represents metadata that cannot be represented by other HTML meta-related elements, like <base>, <link>, <script>, <style> or <title>.\") elements should be used.\n*   `googlebot`, a synonym of `robots`, is only followed by Googlebot (the indexing crawler for Google).\n*   `publisher` which defines the name of the document's publisher.\n*   `robots` which defines the behaviour that cooperative crawlers, or \"robots\", should use with the page. It is a comma-separated list of the values below:\n    \n    Values for the content of `<meta name=\"robots\">`\n    \n    Value\n    \n    Description\n    \n    Used by\n    \n    `index`\n    \n    Allows the robot to index the page (default).\n    \n    All\n    \n    `noindex`\n    \n    Requests the robot to not index the page.\n    \n    All\n    \n    `follow`\n    \n    Allows the robot to follow the links on the page (default).\n    \n    All\n    \n    `nofollow`\n    \n    Requests the robot to not follow the links on the page.\n    \n    All\n    \n    `none`\n    \n    Equivalent to `noindex, nofollow`\n    \n    [Google](https://support.google.com/webmasters/answer/79812)\n    \n    `noodp`\n    \n    Prevents using the [Open Directory Project](https://www.dmoz.org/) description, if any, as the page description in search engine results.\n    \n    [Google](https://support.google.com/webmasters/answer/35624#nodmoz), [Yahoo](https://help.yahoo.com/kb/search-for-desktop/meta-tags-robotstxt-yahoo-search-sln2213.html#cont5), [Bing](https://www.bing.com/webmaster/help/which-robots-metatags-does-bing-support-5198d240)\n    \n    `noarchive`\n    \n    Requests the search engine not to cache the page content.\n    \n    [Google](https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag#valid-indexing--serving-directives), [Yahoo](https://help.yahoo.com/kb/search-for-desktop/SLN2213.html), [Bing](https://www.bing.com/webmaster/help/which-robots-metatags-does-bing-support-5198d240)\n    \n    `nosnippet`\n    \n    Prevents displaying any description of the page in search engine results.\n    \n    [Google](https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag#valid-indexing--serving-directives), [Bing](https://www.bing.com/webmaster/help/which-robots-metatags-does-bing-support-5198d240)\n    \n    `noimageindex`\n    \n    Requests this page not to appear as the referring page of an indexed image.\n    \n    [Google](https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag#valid-indexing--serving-directives)\n    \n    `nocache`\n    \n    Synonym of `noarchive`.\n    \n    [Bing](https://www.bing.com/webmaster/help/which-robots-metatags-does-bing-support-5198d240)\n    \n    **Notes:**\n    \n    *   Only cooperative robots follow these rules. Do not expect to prevent e-mail harvesters with them.\n    *   The robot still needs to access the page in order to read these rules. To prevent bandwidth consumption, use a _[robots.txt](https://developer.mozilla.org/en-US/docs/Glossary/robots.txt \"robots.txt: Robots.txt is a file which is usually placed in the root of any website. It decides whether crawlers are permitted or forbidden access to the web site.\")_ file.\n    *   If you want to remove a page, `noindex` will work, but only after the robot visits the page again. Ensure that the `robots.txt` file is not preventing revisits.\n    *   Some values are mutually exclusive, like `index` and `noindex`, or `follow` and `nofollow`. In these cases the robot's behaviour is undefined and may vary between them.\n    *   Some crawler robots, like Google, Yahoo and Bing, support the same values for the HTTP header `X-Robots-Tag`; this allows non-HTML documents like images to use these rules.\n    \n*   `slurp`, is a synonym of `robots`, but only for Slurp - the crawler for Yahoo Search.\n*   `viewport`, which gives hints about the size of the initial size of the [viewport](https://developer.mozilla.org/en-US/docs/Glossary/viewport \"viewport: A viewport represents a polygonal (normally rectangular) area in computer graphics that is currently being viewed. In web browser terms, it refers to the part of the document you're viewing which is currently visible in its window (or the screen, if the document is being viewed in full screen mode). Content outside the viewport is not visible onscreen until scrolled into view.\"). Used by mobile devices only.\n    \n    Values for the content of `<meta name=\"viewport\">`\n    \n    Value\n    \n    Possible subvalues\n    \n    Description\n    \n    `width`\n    \n    A positive integer number, or the text `device-width`\n    \n    Defines the pixel width of the viewport that you want the web site to be rendered at.\n    \n    `height`\n    \n    A positive integer, or the text `device-height`\n    \n    Defines the height of the viewport. Not used by any browser.\n    \n    `initial-scale`\n    \n    A positive number between `0.0` and `10.0`\n    \n    Defines the ratio between the device width (`device-width` in portrait mode or `device-height` in landscape mode) and the viewport size.\n    \n    `maximum-scale`\n    \n    A positive number between `0.0` and `10.0`\n    \n    Defines the maximum amount to zoom in. It must be greater or equal to the `minimum-scale` or the behaviour is undefined. Browser settings can ignore this rule and iOS10+ ignores it by default.\n    \n    `minimum-scale`\n    \n    A positive number between `0.0` and `10.0`\n    \n    Defines the minimum zoom level. It must be smaller or equal to the `maximum-scale` or the behaviour is undefined. Browser settings can ignore this rule and iOS10+ ignores it by default.\n    \n    `user-scalable`\n    \n    `yes` or `no`\n    \n    If set to `no`, the user is not able to zoom in the webpage. The default is `yes`. Browser settings can ignore this rule, and iOS10+ ignores it by default.\n    \n    Specification\n    \n    Status\n    \n    Comment\n    \n    [CSS Device Adaptation  \n    The definition of '<meta name=\"viewport\">' in that specification.](https://drafts.csswg.org/css-device-adapt/#viewport-meta)\n    \n    Working Draft\n    \n    Non-normatively describes the Viewport META element\n    \n    See also: [`@viewport`](https://developer.mozilla.org/en-US/docs/Web/CSS/@viewport \"The @viewport CSS at-rule lets you configure the viewport through which the document is viewed. It's primarily used for mobile devices, but is also used by desktop browsers that support features like \"snap to edge\" (such as Microsoft Edge).\")\n    \n    **Notes:**\n    \n    *   Though unstandardized, this declaration is respected by most mobile browsers due to de-facto dominance.\n    *   The default values may vary between devices and browsers.\n    *   To learn about this declaration in Firefox for Mobile, see [this article](https://developer.mozilla.org/en-US/docs/Mobile/Viewport_meta_tag \"Mobile/Viewport meta tag\")."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -205,6 +487,20 @@
           "description": {
             "kind": "markdown",
             "value": "Defines a pragma directive. The attribute is named `**http-equiv**(alent)` because all the allowed values are names of particular HTTP headers:\n\n*   `\"content-language\"`  \n    Defines the default language of the page. It can be overridden by the [lang](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) attribute on any element.\n    \n    **Warning:** Do not use this value, as it is obsolete. Prefer the `lang` attribute on the [`<html>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html \"The HTML <html> element represents the root (top-level element) of an HTML document, so it is also referred to as the root element. All other elements must be descendants of this element.\") element.\n    \n*   `\"content-security-policy\"`  \n    Allows page authors to define a [content policy](https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives) for the current page. Content policies mostly specify allowed server origins and script endpoints which help guard against cross-site scripting attacks.\n*   `\"content-type\"`  \n    Defines the [MIME type](https://developer.mozilla.org/en-US/docs/Glossary/MIME_type) of the document, followed by its character encoding. It follows the same syntax as the HTTP `content-type` entity-header field, but as it is inside a HTML page, most values other than `text/html` are impossible. Therefore the valid syntax for its `content` is the string '`text/html`' followed by a character set with the following syntax: '`; charset=_IANAcharset_`', where `IANAcharset` is the _preferred MIME name_ for a character set as [defined by the IANA.](https://www.iana.org/assignments/character-sets)\n    \n    **Warning:** Do not use this value, as it is obsolete. Use the [`charset`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-charset) attribute on the [`<meta>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta \"The HTML <meta> element represents metadata that cannot be represented by other HTML meta-related elements, like <base>, <link>, <script>, <style> or <title>.\") element.\n    \n    **Note:** As [`<meta>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta \"The HTML <meta> element represents metadata that cannot be represented by other HTML meta-related elements, like <base>, <link>, <script>, <style> or <title>.\") can't change documents' types in XHTML or HTML5's XHTML serialization, never set the MIME type to an XHTML MIME type with `<meta>`.\n    \n*   `\"refresh\"`  \n    This instruction specifies:\n    *   The number of seconds until the page should be reloaded - only if the [`content`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-content) attribute contains a positive integer.\n    *   The number of seconds until the page should redirect to another - only if the [`content`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-content) attribute contains a positive integer followed by the string '`;url=`', and a valid URL.\n*   `\"set-cookie\"`  \n    Defines a [cookie](https://developer.mozilla.org/en-US/docs/cookie) for the page. Its content must follow the syntax defined in the [IETF HTTP Cookie Specification](https://tools.ietf.org/html/draft-ietf-httpstate-cookie-14).\n    \n    **Warning:** Do not use this instruction, as it is obsolete. Use the HTTP header [`Set-Cookie`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) instead."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -212,6 +508,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute contains the value for the [`http-equiv`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-http-equiv) or [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-name) attribute, depending on which is used."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -219,11 +529,37 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute declares the page's character encoding. It must contain a [standard IANA MIME name for character encodings](https://www.iana.org/assignments/character-sets). Although the standard doesn't request a specific encoding, it suggests:\n\n*   Authors are encouraged to use [`UTF-8`](https://developer.mozilla.org/en-US/docs/Glossary/UTF-8).\n*   Authors should not use ASCII-incompatible encodings to avoid security risk: browsers not supporting them may interpret harmful content as HTML. This happens with the `JIS_C6226-1983`, `JIS_X0212-1990`, `HZ-GB-2312`, `JOHAB`, the ISO-2022 family and the EBCDIC family.\n\n**Note:** ASCII-incompatible encodings are those that don't map the 8-bit code points `0x20` to `0x7E` to the `0x0020` to `0x007E` Unicode code points)\n\n*   Authors **must not** use `CESU-8`, `UTF-7`, `BOCU-1` and/or `SCSU` as [cross-site scripting](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting) attacks with these encodings have been demonstrated.\n*   Authors should not use `UTF-32` because not all HTML5 encoding algorithms can distinguish it from `UTF-16`.\n\n**Notes:**\n\n*   The declared character encoding must match the one the page was saved with to avoid garbled characters and security holes.\n*   The [`<meta>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta \"The HTML <meta> element represents metadata that cannot be represented by other HTML meta-related elements, like <base>, <link>, <script>, <style> or <title>.\") element declaring the encoding must be inside the [`<head>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head \"The HTML <head> element provides general information (metadata) about the document, including its title and links to its scripts and style sheets.\") element and **within the first 1024 bytes** of the HTML as some browsers only look at those bytes before choosing an encoding.\n*   This [`<meta>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta \"The HTML <meta> element represents metadata that cannot be represented by other HTML meta-related elements, like <base>, <link>, <script>, <style> or <title>.\") element is only one part of the [algorithm to determine a page's character set](https://www.whatwg.org/specs/web-apps/current-work/multipage/parsing.html#encoding-sniffing-algorithm \"Algorithm charset page\"). The [`Content-Type` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) and any [Byte-Order Marks](https://developer.mozilla.org/en-US/docs/Glossary/Byte-Order_Mark \"The definition of that term (Byte-Order Marks) has not been written yet; please consider contributing it!\") override this element.\n*   It is strongly recommended to define the character encoding. If a page's encoding is undefined, cross-scripting techniques are possible, such as the [`UTF-7` fallback cross-scripting technique](https://code.google.com/p/doctype-mirror/wiki/ArticleUtf7).\n*   The [`<meta>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta \"The HTML <meta> element represents metadata that cannot be represented by other HTML meta-related elements, like <base>, <link>, <script>, <style> or <title>.\") element with a `charset` attribute is a synonym for the pre-HTML5 `<meta http-equiv=\"Content-Type\" content=\"text/html; charset=_IANAcharset_\">`, where _`IANAcharset`_ contains the value of the equivalent [`charset`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-charset) attribute. This syntax is still allowed, although no longer recommended."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
           "name": "scheme",
-          "description": "This attribute defines the scheme in which metadata is described. A scheme is a context leading to the correct interpretations of the [`content`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-content) value, like a format.\n\n**Warning:** Do not use this value, as it is obsolete. There is no replacement as there was no real usage for it."
+          "description": "This attribute defines the scheme in which metadata is described. A scheme is a context leading to the correct interpretations of the [`content`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-content) value, like a format.\n\n**Warning:** Do not use this value, as it is obsolete. There is no replacement as there was no real usage for it.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -231,7 +567,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/meta"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "style",
@@ -245,6 +595,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute defines which media the style should be applied to. Its value is a [media query](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Media_queries), which defaults to `all` if the attribute is missing."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -259,6 +623,18 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute defines the styling language as a MIME type (charset should not be specified). This attribute is optional and defaults to `text/css` if it is not specified — there is very little reason to include this in modern web documents."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": false
           }
         },
         {
@@ -275,7 +651,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/style"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "body",
@@ -369,27 +759,99 @@
         },
         {
           "name": "alink",
-          "description": "Color of text for hyperlinks when selected. _This method is non-conforming, use CSS [`color`](https://developer.mozilla.org/en-US/docs/Web/CSS/color \"The color CSS property sets the foreground color value of an element's text and text decorations, and sets the currentcolor value.\") property in conjunction with the [`:active`](https://developer.mozilla.org/en-US/docs/Web/CSS/:active \"The :active CSS pseudo-class represents an element (such as a button) that is being activated by the user.\") pseudo-class instead._"
+          "description": "Color of text for hyperlinks when selected. _This method is non-conforming, use CSS [`color`](https://developer.mozilla.org/en-US/docs/Web/CSS/color \"The color CSS property sets the foreground color value of an element's text and text decorations, and sets the currentcolor value.\") property in conjunction with the [`:active`](https://developer.mozilla.org/en-US/docs/Web/CSS/:active \"The :active CSS pseudo-class represents an element (such as a button) that is being activated by the user.\") pseudo-class instead._",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "background",
-          "description": "URI of a image to use as a background. _This method is non-conforming, use CSS [`background`](https://developer.mozilla.org/en-US/docs/Web/CSS/background \"The background shorthand CSS property sets all background style properties at once, such as color, image, origin and size, or repeat method.\") property on the element instead._"
+          "description": "URI of a image to use as a background. _This method is non-conforming, use CSS [`background`](https://developer.mozilla.org/en-US/docs/Web/CSS/background \"The background shorthand CSS property sets all background style properties at once, such as color, image, origin and size, or repeat method.\") property on the element instead._",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "bgcolor",
-          "description": "Background color for the document. _This method is non-conforming, use CSS [`background-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-color \"The background-color CSS property sets the background color of an element.\") property on the element instead._"
+          "description": "Background color for the document. _This method is non-conforming, use CSS [`background-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-color \"The background-color CSS property sets the background color of an element.\") property on the element instead._",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "bottommargin",
-          "description": "The margin of the bottom of the body. _This method is non-conforming, use CSS [`margin-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom \"The margin-bottom CSS property sets the margin area on the bottom of an element. A positive value places it farther from its neighbors, while a negative value places it closer.\") property on the element instead._"
+          "description": "The margin of the bottom of the body. _This method is non-conforming, use CSS [`margin-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom \"The margin-bottom CSS property sets the margin area on the bottom of an element. A positive value places it farther from its neighbors, while a negative value places it closer.\") property on the element instead._",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E79",
+            "FF35",
+            "FFA35",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "leftmargin",
-          "description": "The margin of the left of the body. _This method is non-conforming, use CSS [`margin-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-left \"The margin-left CSS property sets the margin area on the left side of an element. A positive value places it farther from its neighbors, while a negative value places it closer.\") property on the element instead._"
+          "description": "The margin of the left of the body. _This method is non-conforming, use CSS [`margin-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-left \"The margin-left CSS property sets the margin area on the left side of an element. A positive value places it farther from its neighbors, while a negative value places it closer.\") property on the element instead._",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E79",
+            "FF35",
+            "FFA35",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "link",
-          "description": "Color of text for unvisited hypertext links. _This method is non-conforming, use CSS [`color`](https://developer.mozilla.org/en-US/docs/Web/CSS/color \"The color CSS property sets the foreground color value of an element's text and text decorations, and sets the currentcolor value.\") property in conjunction with the [`:link`](https://developer.mozilla.org/en-US/docs/Web/CSS/:link \"The :link CSS pseudo-class represents an element that has not yet been visited. It matches every unvisited <a>, <area>, or <link> element that has an href attribute.\") pseudo-class instead._"
+          "description": "Color of text for unvisited hypertext links. _This method is non-conforming, use CSS [`color`](https://developer.mozilla.org/en-US/docs/Web/CSS/color \"The color CSS property sets the foreground color value of an element's text and text decorations, and sets the currentcolor value.\") property in conjunction with the [`:link`](https://developer.mozilla.org/en-US/docs/Web/CSS/:link \"The :link CSS pseudo-class represents an element that has not yet been visited. It matches every unvisited <a>, <area>, or <link> element that has an href attribute.\") pseudo-class instead._",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "onblur",
@@ -421,19 +883,67 @@
         },
         {
           "name": "rightmargin",
-          "description": "The margin of the right of the body. _This method is non-conforming, use CSS [`margin-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-right \"The margin-right CSS property sets the margin area on the right side of an element. A positive value places it farther from its neighbors, while a negative value places it closer.\") property on the element instead._"
+          "description": "The margin of the right of the body. _This method is non-conforming, use CSS [`margin-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-right \"The margin-right CSS property sets the margin area on the right side of an element. A positive value places it farther from its neighbors, while a negative value places it closer.\") property on the element instead._",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E79",
+            "FF35",
+            "FFA35",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "text",
-          "description": "Foreground color of text. _This method is non-conforming, use CSS [`color`](https://developer.mozilla.org/en-US/docs/Web/CSS/color \"The color CSS property sets the foreground color value of an element's text and text decorations, and sets the currentcolor value.\") property on the element instead._"
+          "description": "Foreground color of text. _This method is non-conforming, use CSS [`color`](https://developer.mozilla.org/en-US/docs/Web/CSS/color \"The color CSS property sets the foreground color value of an element's text and text decorations, and sets the currentcolor value.\") property on the element instead._",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "topmargin",
-          "description": "The margin of the top of the body. _This method is non-conforming, use CSS [`margin-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-top \"The margin-top CSS property sets the margin area on the top of an element. A positive value places it farther from its neighbors, while a negative value places it closer.\") property on the element instead._"
+          "description": "The margin of the top of the body. _This method is non-conforming, use CSS [`margin-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-top \"The margin-top CSS property sets the margin area on the top of an element. A positive value places it farther from its neighbors, while a negative value places it closer.\") property on the element instead._",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E79",
+            "FF35",
+            "FFA35",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "vlink",
-          "description": "Color of text for visited hypertext links. _This method is non-conforming, use CSS [`color`](https://developer.mozilla.org/en-US/docs/Web/CSS/color \"The color CSS property sets the foreground color value of an element's text and text decorations, and sets the currentcolor value.\") property in conjunction with the [`:visited`](https://developer.mozilla.org/en-US/docs/Web/CSS/:visited \"The :visited CSS pseudo-class represents links that the user has already visited. For privacy reasons, the styles that can be modified using this selector are very limited.\") pseudo-class instead._"
+          "description": "Color of text for visited hypertext links. _This method is non-conforming, use CSS [`color`](https://developer.mozilla.org/en-US/docs/Web/CSS/color \"The color CSS property sets the foreground color value of an element's text and text decorations, and sets the currentcolor value.\") property in conjunction with the [`:visited`](https://developer.mozilla.org/en-US/docs/Web/CSS/:visited \"The :visited CSS pseudo-class represents links that the user has already visited. For privacy reasons, the styles that can be modified using this selector are very limited.\") pseudo-class instead._",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -441,7 +951,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/body"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "article",
@@ -455,7 +979,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/article"
         }
-      ]
+      ],
+      "browsers": [
+        "C5",
+        "CA18",
+        "E12",
+        "FF4",
+        "FFA4",
+        "S5",
+        "SM4.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "section",
@@ -469,7 +1007,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/section"
         }
-      ]
+      ],
+      "browsers": [
+        "C5",
+        "CA18",
+        "E12",
+        "FF4",
+        "FFA4",
+        "S5",
+        "SM4.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "nav",
@@ -483,7 +1035,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/nav"
         }
-      ]
+      ],
+      "browsers": [
+        "C5",
+        "CA18",
+        "E12",
+        "FF4",
+        "FFA4",
+        "S5",
+        "SM4.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "aside",
@@ -497,7 +1063,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/aside"
         }
-      ]
+      ],
+      "browsers": [
+        "C5",
+        "CA18",
+        "E12",
+        "FF4",
+        "FFA4",
+        "S5",
+        "SM4.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "h1",
@@ -511,7 +1091,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "h2",
@@ -525,7 +1119,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "h3",
@@ -539,7 +1147,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "h4",
@@ -553,7 +1175,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "h5",
@@ -567,7 +1203,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "h6",
@@ -581,7 +1231,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "header",
@@ -595,7 +1259,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/header"
         }
-      ]
+      ],
+      "browsers": [
+        "C5",
+        "CA18",
+        "E12",
+        "FF4",
+        "FFA4",
+        "S5",
+        "SM4.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "footer",
@@ -609,7 +1287,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/footer"
         }
-      ]
+      ],
+      "browsers": [
+        "C5",
+        "CA18",
+        "E12",
+        "FF4",
+        "FFA4",
+        "S5",
+        "SM4.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "address",
@@ -623,7 +1315,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/address"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "p",
@@ -637,7 +1343,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/p"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "hr",
@@ -649,23 +1369,83 @@
       "attributes": [
         {
           "name": "align",
-          "description": "Sets the alignment of the rule on the page. If no value is specified, the default value is `left`."
+          "description": "Sets the alignment of the rule on the page. If no value is specified, the default value is `left`.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "color",
-          "description": "Sets the color of the rule through color name or hexadecimal value."
+          "description": "Sets the color of the rule through color name or hexadecimal value.",
+          "browsers": [
+            "C33",
+            "CA33",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S10.1",
+            "SM10.3"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "noshade",
-          "description": "Sets the rule to have no shading."
+          "description": "Sets the rule to have no shading.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "size",
-          "description": "Sets the height, in pixels, of the rule."
+          "description": "Sets the height, in pixels, of the rule.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "width",
-          "description": "Sets the length of the rule on the page through a pixel or percentage value."
+          "description": "Sets the length of the rule on the page through a pixel or percentage value.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -673,7 +1453,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/hr"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S3",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "pre",
@@ -688,11 +1482,27 @@
         },
         {
           "name": "width",
-          "description": "Contains the _preferred_ count of characters that a line should have. Though technically still implemented, this attribute has no visual effect; to achieve such an effect, use CSS [`width`](https://developer.mozilla.org/en-US/docs/Web/CSS/width \"The width CSS property sets an element's width. By default it sets the width of the content area, but if box-sizing is set to border-box, it sets the width of the border area.\") instead."
+          "description": "Contains the _preferred_ count of characters that a line should have. Though technically still implemented, this attribute has no visual effect; to achieve such an effect, use CSS [`width`](https://developer.mozilla.org/en-US/docs/Web/CSS/width \"The width CSS property sets an element's width. By default it sets the width of the content area, but if box-sizing is set to border-box, it sets the width of the border area.\") instead.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "wrap",
-          "description": "Is a _hint_ indicating how the overflow must happen. In modern browser this hint is ignored and no visual effect results in its present; to achieve such an effect, use CSS [`white-space`](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space \"The white-space CSS property sets how white space inside an element is handled.\") instead."
+          "description": "Is a _hint_ indicating how the overflow must happen. In modern browser this hint is ignored and no visual effect results in its present; to achieve such an effect, use CSS [`white-space`](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space \"The white-space CSS property sets how white space inside an element is handled.\") instead.",
+          "browsers": [],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -700,7 +1510,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/pre"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "blockquote",
@@ -714,6 +1538,20 @@
           "description": {
             "kind": "markdown",
             "value": "A URL that designates a source document or message for the information quoted. This attribute is intended to point to information explaining the context or the reference for the quote."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         }
       ],
@@ -722,7 +1560,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/blockquote"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "ol",
@@ -737,6 +1589,20 @@
           "description": {
             "kind": "markdown",
             "value": "This Boolean attribute specifies that the items of the list are specified in reversed order."
+          },
+          "browsers": [
+            "C18",
+            "CA18",
+            "E79",
+            "FF18",
+            "FFA18",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "≤2020-01-15",
+            "baseline_high_date": "≤2022-07-15"
           }
         },
         {
@@ -744,6 +1610,20 @@
           "description": {
             "kind": "markdown",
             "value": "This integer attribute specifies the start value for numbering the individual list items. Although the ordering type of list elements might be Roman numerals, such as XXXI, or letters, the value of start is always represented as a number. To start numbering elements from the letter \"C\", use `<ol start=\"3\">`.\n\n**Note**: This attribute was deprecated in HTML4, but reintroduced in HTML5."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -752,11 +1632,37 @@
           "description": {
             "kind": "markdown",
             "value": "Indicates the numbering type:\n\n*   `'a'` indicates lowercase letters,\n*   `'A'` indicates uppercase letters,\n*   `'i'` indicates lowercase Roman numerals,\n*   `'I'` indicates uppercase Roman numerals,\n*   and `'1'` indicates numbers (default).\n\nThe type set is used for the entire list unless a different [`type`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li#attr-type) attribute is used within an enclosed [`<li>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li \"The HTML <li> element is used to represent an item in a list. It must be contained in a parent element: an ordered list (<ol>), an unordered list (<ul>), or a menu (<menu>). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter.\") element.\n\n**Note:** This attribute was deprecated in HTML4, but reintroduced in HTML5.\n\nUnless the value of the list number matters (e.g. in legal or technical documents where items are to be referenced by their number/letter), the CSS [`list-style-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type \"The list-style-type CSS property sets the marker (such as a disc, character, or custom counter style) of a list item element.\") property should be used instead."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
           "name": "compact",
-          "description": "This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute depends on the user agent and it doesn't work in all browsers.\n\n**Warning:** Do not use this attribute, as it has been deprecated: the [`<ol>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol \"The HTML <ol> element represents an ordered list of items, typically rendered as a numbered list.\") element should be styled using [CSS](https://developer.mozilla.org/en-US/docs/CSS). To give an effect similar to the `compact` attribute, the [CSS](https://developer.mozilla.org/en-US/docs/CSS) property [`line-height`](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height \"The line-height CSS property sets the amount of space used for lines, such as in text. On block-level elements, it specifies the minimum height of line boxes within the element. On non-replaced inline elements, it specifies the height that is used to calculate line box height.\") can be used with a value of `80%`."
+          "description": "This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute depends on the user agent and it doesn't work in all browsers.\n\n**Warning:** Do not use this attribute, as it has been deprecated: the [`<ol>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol \"The HTML <ol> element represents an ordered list of items, typically rendered as a numbered list.\") element should be styled using [CSS](https://developer.mozilla.org/en-US/docs/CSS). To give an effect similar to the `compact` attribute, the [CSS](https://developer.mozilla.org/en-US/docs/CSS) property [`line-height`](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height \"The line-height CSS property sets the amount of space used for lines, such as in text. On block-level elements, it specifies the minimum height of line boxes within the element. On non-replaced inline elements, it specifies the height that is used to calculate line box height.\") can be used with a value of `80%`.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -764,7 +1670,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/ol"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "ul",
@@ -775,7 +1695,19 @@
       "attributes": [
         {
           "name": "compact",
-          "description": "This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute depends on the user agent and it doesn't work in all browsers.\n\n**Usage note: **Do not use this attribute, as it has been deprecated: the [`<ul>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul \"The HTML <ul> element represents an unordered list of items, typically rendered as a bulleted list.\") element should be styled using [CSS](https://developer.mozilla.org/en-US/docs/CSS). To give a similar effect as the `compact` attribute, the [CSS](https://developer.mozilla.org/en-US/docs/CSS) property [line-height](https://developer.mozilla.org/en-US/docs/CSS/line-height) can be used with a value of `80%`."
+          "description": "This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute depends on the user agent and it doesn't work in all browsers.\n\n**Usage note: **Do not use this attribute, as it has been deprecated: the [`<ul>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul \"The HTML <ul> element represents an unordered list of items, typically rendered as a bulleted list.\") element should be styled using [CSS](https://developer.mozilla.org/en-US/docs/CSS). To give a similar effect as the `compact` attribute, the [CSS](https://developer.mozilla.org/en-US/docs/CSS) property [line-height](https://developer.mozilla.org/en-US/docs/CSS/line-height) can be used with a value of `80%`.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -783,7 +1715,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/ul"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "li",
@@ -797,11 +1743,37 @@
           "description": {
             "kind": "markdown",
             "value": "This integer attribute indicates the current ordinal value of the list item as defined by the [`<ol>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol \"The HTML <ol> element represents an ordered list of items, typically rendered as a numbered list.\") element. The only allowed value for this attribute is a number, even if the list is displayed with Roman numerals or letters. List items that follow this one continue numbering from the value set. The **value** attribute has no meaning for unordered lists ([`<ul>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul \"The HTML <ul> element represents an unordered list of items, typically rendered as a bulleted list.\")) or for menus ([`<menu>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu \"The HTML <menu> element represents a group of commands that a user can perform or activate. This includes both list menus, which might appear across the top of a screen, as well as context menus, such as those that might appear underneath a button after it has been clicked.\")).\n\n**Note**: This attribute was deprecated in HTML4, but reintroduced in HTML5.\n\n**Note:** Prior to Gecko 9.0, negative values were incorrectly converted to 0. Starting in Gecko 9.0 all integer values are correctly parsed."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
           "name": "type",
-          "description": "This character attribute indicates the numbering type:\n\n*   `a`: lowercase letters\n*   `A`: uppercase letters\n*   `i`: lowercase Roman numerals\n*   `I`: uppercase Roman numerals\n*   `1`: numbers\n\nThis type overrides the one used by its parent [`<ol>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol \"The HTML <ol> element represents an ordered list of items, typically rendered as a numbered list.\") element, if any.\n\n**Usage note:** This attribute has been deprecated: use the CSS [`list-style-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type \"The list-style-type CSS property sets the marker (such as a disc, character, or custom counter style) of a list item element.\") property instead."
+          "description": "This character attribute indicates the numbering type:\n\n*   `a`: lowercase letters\n*   `A`: uppercase letters\n*   `i`: lowercase Roman numerals\n*   `I`: uppercase Roman numerals\n*   `1`: numbers\n\nThis type overrides the one used by its parent [`<ol>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol \"The HTML <ol> element represents an ordered list of items, typically rendered as a numbered list.\") element, if any.\n\n**Usage note:** This attribute has been deprecated: use the CSS [`list-style-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type \"The list-style-type CSS property sets the marker (such as a disc, character, or custom counter style) of a list item element.\") property instead.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -809,7 +1781,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/li"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S3",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "dl",
@@ -823,7 +1809,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/dl"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "dt",
@@ -837,7 +1837,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/dt"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "dd",
@@ -856,7 +1870,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/dd"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "figure",
@@ -870,7 +1898,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/figure"
         }
-      ]
+      ],
+      "browsers": [
+        "C8",
+        "CA18",
+        "E12",
+        "FF4",
+        "FFA4",
+        "S5.1",
+        "SM5"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "figcaption",
@@ -884,7 +1926,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/figcaption"
         }
-      ]
+      ],
+      "browsers": [
+        "C8",
+        "CA18",
+        "E12",
+        "FF4",
+        "FFA4",
+        "S5.1",
+        "SM5"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "main",
@@ -898,7 +1954,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/main"
         }
-      ]
+      ],
+      "browsers": [
+        "C26",
+        "CA26",
+        "E12",
+        "FF21",
+        "FFA21",
+        "S7",
+        "SM7"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "div",
@@ -912,7 +1982,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/div"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "a",
@@ -926,6 +2010,20 @@
           "description": {
             "kind": "markdown",
             "value": "Contains a URL or a URL fragment that the hyperlink points to.\nA URL fragment is a name preceded by a hash mark (`#`), which specifies an internal target location (an [`id`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-id) of an HTML element) within the current document. URLs are not restricted to Web (HTTP)-based documents, but can use any protocol supported by the browser. For example, [`file:`](https://en.wikipedia.org/wiki/File_URI_scheme), `ftp:`, and `mailto:` work in most browsers.\n\n**Note:** You can use `href=\"#top\"` or the empty fragment `href=\"#\"` to link to the top of the current page. [This behavior is specified by HTML5](https://www.w3.org/TR/html5/single-page.html#scroll-to-fragid)."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -934,6 +2032,20 @@
           "description": {
             "kind": "markdown",
             "value": "Specifies where to display the linked URL. It is a name of, or keyword for, a _browsing context_: a tab, window, or `<iframe>`. The following keywords have special meanings:\n\n*   `_self`: Load the URL into the same browsing context as the current one. This is the default behavior.\n*   `_blank`: Load the URL into a new browsing context. This is usually a tab, but users can configure browsers to use new windows instead.\n*   `_parent`: Load the URL into the parent browsing context of the current one. If there is no parent, this behaves the same way as `_self`.\n*   `_top`: Load the URL into the top-level browsing context (that is, the \"highest\" browsing context that is an ancestor of the current one, and has no parent). If there is no parent, this behaves the same way as `_self`.\n\n**Note:** When using `target`, consider adding `rel=\"noreferrer\"` to avoid exploitation of the `window.opener` API.\n\n**Note:** Linking to another page using `target=\"_blank\"` will run the new page on the same process as your page. If the new page is executing expensive JS, your page's performance may suffer. To avoid this use `rel=\"noopener\"`."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -941,6 +2053,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute instructs browsers to download a URL instead of navigating to it, so the user will be prompted to save it as a local file. If the attribute has a value, it is used as the pre-filled file name in the Save prompt (the user can still change the file name if they want). There are no restrictions on allowed values, though `/` and `\\` are converted to underscores. Most file systems limit some punctuation in file names, and browsers will adjust the suggested name accordingly.\n\n**Notes:**\n\n*   This attribute only works for [same-origin URLs](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy).\n*   Although HTTP(s) URLs need to be in the same-origin, [`blob:` URLs](https://developer.mozilla.org/en-US/docs/Web/API/URL.createObjectURL) and [`data:` URLs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) are allowed so that content generated by JavaScript, such as pictures created in an image-editor Web app, can be downloaded.\n*   If the HTTP header [`Content-Disposition:`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) gives a different filename than this attribute, the HTTP header takes priority over this attribute.\n*   If `Content-Disposition:` is set to `inline`, Firefox prioritizes `Content-Disposition`, like the filename case, while Chrome prioritizes the `download` attribute."
+          },
+          "browsers": [
+            "C14",
+            "CA18",
+            "E18",
+            "FF20",
+            "FFA20",
+            "S10.1",
+            "SM13"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2019-09-19",
+            "baseline_high_date": "2022-03-19"
           }
         },
         {
@@ -948,6 +2074,16 @@
           "description": {
             "kind": "markdown",
             "value": "Contains a space-separated list of URLs to which, when the hyperlink is followed, [`POST`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST \"The HTTP POST method sends data to the server. The type of the body of the request is indicated by the Content-Type header.\") requests with the body `PING` will be sent by the browser (in the background). Typically used for tracking."
+          },
+          "browsers": [
+            "C12",
+            "CA18",
+            "E17",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": false
           }
         },
         {
@@ -955,6 +2091,20 @@
           "description": {
             "kind": "markdown",
             "value": "Specifies the relationship of the target object to the link object. The value is a space-separated list of [link types](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types)."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -962,6 +2112,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute indicates the human language of the linked resource. It is purely advisory, with no built-in functionality. Allowed values are determined by [BCP47](https://www.ietf.org/rfc/bcp/bcp47.txt \"Tags for Identifying Languages\")."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -969,11 +2133,39 @@
           "description": {
             "kind": "markdown",
             "value": "Specifies the media type in the form of a [MIME type](https://developer.mozilla.org/en-US/docs/Glossary/MIME_type \"MIME type: A MIME type (now properly called \"media type\", but also sometimes \"content type\") is a string sent along with a file indicating the type of the file (describing the content format, for example, a sound file might be labeled audio/ogg, or an image file image/png).\") for the linked URL. It is purely advisory, with no built-in functionality."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
           "name": "referrerpolicy",
-          "description": "Indicates which [referrer](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer) to send when fetching the URL:\n\n*   `'no-referrer'` means the `Referer:` header will not be sent.\n*   `'no-referrer-when-downgrade'` means no `Referer:` header will be sent when navigating to an origin without HTTPS. This is the default behavior.\n*   `'origin'` means the referrer will be the [origin](https://developer.mozilla.org/en-US/docs/Glossary/Origin) of the page, not including information after the domain.\n*   `'origin-when-cross-origin'` meaning that navigations to other origins will be limited to the scheme, the host and the port, while navigations on the same origin will include the referrer's path.\n*   `'strict-origin-when-cross-origin'`\n*   `'unsafe-url'` means the referrer will include the origin and path, but not the fragment, password, or username. This is unsafe because it can leak data from secure URLs to insecure ones."
+          "description": "Indicates which [referrer](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer) to send when fetching the URL:\n\n*   `'no-referrer'` means the `Referer:` header will not be sent.\n*   `'no-referrer-when-downgrade'` means no `Referer:` header will be sent when navigating to an origin without HTTPS. This is the default behavior.\n*   `'origin'` means the referrer will be the [origin](https://developer.mozilla.org/en-US/docs/Glossary/Origin) of the page, not including information after the domain.\n*   `'origin-when-cross-origin'` meaning that navigations to other origins will be limited to the scheme, the host and the port, while navigations on the same origin will include the referrer's path.\n*   `'strict-origin-when-cross-origin'`\n*   `'unsafe-url'` means the referrer will include the origin and path, but not the fragment, password, or username. This is unsafe because it can leak data from secure URLs to insecure ones.",
+          "browsers": [
+            "C51",
+            "CA51",
+            "E79",
+            "FF50",
+            "FFA50",
+            "S14",
+            "SM14"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2020-09-16",
+            "baseline_high_date": "2023-03-16"
+          }
         }
       ],
       "references": [
@@ -981,7 +2173,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/a"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "em",
@@ -995,7 +2201,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/em"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "strong",
@@ -1009,7 +2229,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/strong"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "small",
@@ -1023,7 +2257,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/small"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "s",
@@ -1037,7 +2285,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/s"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "cite",
@@ -1051,7 +2313,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/cite"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "q",
@@ -1065,6 +2341,20 @@
           "description": {
             "kind": "markdown",
             "value": "The value of this attribute is a URL that designates a source document or message for the information quoted. This attribute is intended to point to information explaining the context or the reference for the quote."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         }
       ],
@@ -1073,7 +2363,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/q"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S3",
+        "SM2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "dfn",
@@ -1087,7 +2391,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/dfn"
         }
-      ]
+      ],
+      "browsers": [
+        "C15",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S6",
+        "SM6"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "abbr",
@@ -1101,7 +2419,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/abbr"
         }
-      ]
+      ],
+      "browsers": [
+        "C2",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "ruby",
@@ -1115,7 +2447,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/ruby"
         }
-      ]
+      ],
+      "browsers": [
+        "C5",
+        "CA18",
+        "E12",
+        "FF38",
+        "FFA38",
+        "S5",
+        "SM4.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "rb",
@@ -1143,7 +2489,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/rt"
         }
-      ]
+      ],
+      "browsers": [
+        "C5",
+        "CA18",
+        "E12",
+        "FF38",
+        "FFA38",
+        "S5",
+        "SM4.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "rp",
@@ -1157,7 +2517,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/rp"
         }
-      ]
+      ],
+      "browsers": [
+        "C5",
+        "CA18",
+        "E12",
+        "FF38",
+        "FFA38",
+        "S5",
+        "SM4.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "time",
@@ -1171,6 +2545,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute indicates the time and/or date of the element and must be in one of the formats described below."
+          },
+          "browsers": [
+            "C62",
+            "CA62",
+            "E14",
+            "FF22",
+            "FFA22",
+            "S7",
+            "SM4"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2017-10-24",
+            "baseline_high_date": "2020-04-24"
           }
         }
       ],
@@ -1179,7 +2567,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/time"
         }
-      ]
+      ],
+      "browsers": [
+        "C62",
+        "CA62",
+        "E14",
+        "FF22",
+        "FFA22",
+        "S7",
+        "SM4"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2017-10-24",
+        "baseline_high_date": "2020-04-24"
+      }
     },
     {
       "name": "code",
@@ -1193,7 +2595,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/code"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "var",
@@ -1207,7 +2623,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/var"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "samp",
@@ -1221,7 +2651,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/samp"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "kbd",
@@ -1235,7 +2679,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/kbd"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "sub",
@@ -1249,7 +2707,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/sub"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "sup",
@@ -1263,7 +2735,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/sup"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "i",
@@ -1277,7 +2763,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/i"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "b",
@@ -1291,7 +2791,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/b"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "u",
@@ -1305,7 +2819,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/u"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "mark",
@@ -1319,7 +2847,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/mark"
         }
-      ]
+      ],
+      "browsers": [
+        "C7",
+        "CA18",
+        "E12",
+        "FF4",
+        "FFA4",
+        "S5.1",
+        "SM5"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "bdi",
@@ -1333,7 +2875,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/bdi"
         }
-      ]
+      ],
+      "browsers": [
+        "C16",
+        "CA18",
+        "E79",
+        "FF10",
+        "FFA10",
+        "S6",
+        "SM6"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2020-01-15",
+        "baseline_high_date": "2022-07-15"
+      }
     },
     {
       "name": "bdo",
@@ -1352,7 +2908,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/bdo"
         }
-      ]
+      ],
+      "browsers": [
+        "C15",
+        "CA18",
+        "E12",
+        "FF10",
+        "FFA10",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "span",
@@ -1366,7 +2936,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/span"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "br",
@@ -1378,7 +2962,19 @@
       "attributes": [
         {
           "name": "clear",
-          "description": "Indicates where to begin the next line after the break."
+          "description": "Indicates where to begin the next line after the break.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -1386,7 +2982,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/br"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "wbr",
@@ -1401,7 +3011,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/wbr"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "ins",
@@ -1412,11 +3036,39 @@
       "attributes": [
         {
           "name": "cite",
-          "description": "This attribute defines the URI of a resource that explains the change, such as a link to meeting minutes or a ticket in a troubleshooting system."
+          "description": "This attribute defines the URI of a resource that explains the change, such as a link to meeting minutes or a ticket in a troubleshooting system.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "datetime",
-          "description": "This attribute indicates the time and date of the change and must be a valid date with an optional time string. If the value cannot be parsed as a date with an optional time string, the element does not have an associated time stamp. For the format of the string without a time, see [Format of a valid date string](https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#Format_of_a_valid_date_string \"Certain HTML elements use date and/or time values. The formats of the strings that specify these are described in this article.\") in [Date and time formats used in HTML](https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats \"Certain HTML elements use date and/or time values. The formats of the strings that specify these are described in this article.\"). The format of the string if it includes both date and time is covered in [Format of a valid local date and time string](https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#Format_of_a_valid_local_date_and_time_string \"Certain HTML elements use date and/or time values. The formats of the strings that specify these are described in this article.\") in [Date and time formats used in HTML](https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats \"Certain HTML elements use date and/or time values. The formats of the strings that specify these are described in this article.\")."
+          "description": "This attribute indicates the time and date of the change and must be a valid date with an optional time string. If the value cannot be parsed as a date with an optional time string, the element does not have an associated time stamp. For the format of the string without a time, see [Format of a valid date string](https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#Format_of_a_valid_date_string \"Certain HTML elements use date and/or time values. The formats of the strings that specify these are described in this article.\") in [Date and time formats used in HTML](https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats \"Certain HTML elements use date and/or time values. The formats of the strings that specify these are described in this article.\"). The format of the string if it includes both date and time is covered in [Format of a valid local date and time string](https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#Format_of_a_valid_local_date_and_time_string \"Certain HTML elements use date and/or time values. The formats of the strings that specify these are described in this article.\") in [Date and time formats used in HTML](https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats \"Certain HTML elements use date and/or time values. The formats of the strings that specify these are described in this article.\").",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         }
       ],
       "references": [
@@ -1424,7 +3076,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/ins"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "del",
@@ -1438,6 +3104,20 @@
           "description": {
             "kind": "markdown",
             "value": "A URI for a resource that explains the change (for example, meeting minutes)."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1445,6 +3125,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute indicates the time and date of the change and must be a valid date string with an optional time. If the value cannot be parsed as a date with an optional time string, the element does not have an associated time stamp. For the format of the string without a time, see [Format of a valid date string](https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#Format_of_a_valid_date_string \"Certain HTML elements use date and/or time values. The formats of the strings that specify these are described in this article.\") in [Date and time formats used in HTML](https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats \"Certain HTML elements use date and/or time values. The formats of the strings that specify these are described in this article.\"). The format of the string if it includes both date and time is covered in [Format of a valid local date and time string](https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#Format_of_a_valid_local_date_and_time_string \"Certain HTML elements use date and/or time values. The formats of the strings that specify these are described in this article.\") in [Date and time formats used in HTML](https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats \"Certain HTML elements use date and/or time values. The formats of the strings that specify these are described in this article.\")."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         }
       ],
@@ -1453,7 +3147,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/del"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "picture",
@@ -1467,7 +3175,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/picture"
         }
-      ]
+      ],
+      "browsers": [
+        "C38",
+        "CA38",
+        "E13",
+        "FF38",
+        "FFA38",
+        "S9.1",
+        "SM9.3"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2016-03-21",
+        "baseline_high_date": "2018-09-21"
+      }
     },
     {
       "name": "img",
@@ -1482,6 +3204,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute defines an alternative text description of the image.\n\n**Note:** Browsers do not always display the image referenced by the element. This is the case for non-graphical browsers (including those used by people with visual impairments), if the user chooses not to display images, or if the browser cannot display the image because it is invalid or an [unsupported type](#Supported_image_formats). In these cases, the browser may replace the image with the text defined in this element's `alt` attribute. You should, for these reasons and others, provide a useful value for `alt` whenever possible.\n\n**Note:** Omitting this attribute altogether indicates that the image is a key part of the content, and no textual equivalent is available. Setting this attribute to an empty string (`alt=\"\"`) indicates that this image is _not_ a key part of the content (decorative), and that non-visual browsers may omit it from rendering."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1489,6 +3225,20 @@
           "description": {
             "kind": "markdown",
             "value": "The image URL. This attribute is mandatory for the `<img>` element. On browsers supporting `srcset`, `src` is treated like a candidate image with a pixel density descriptor `1x` unless an image with this pixel density descriptor is already defined in `srcset,` or unless `srcset` contains '`w`' descriptors."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1496,6 +3246,20 @@
           "description": {
             "kind": "markdown",
             "value": "A list of one or more strings separated by commas indicating a set of possible image sources for the user agent to use. Each string is composed of:\n\n1.  a URL to an image,\n2.  optionally, whitespace followed by one of:\n    *   A width descriptor, or a positive integer directly followed by '`w`'. The width descriptor is divided by the source size given in the `sizes` attribute to calculate the effective pixel density.\n    *   A pixel density descriptor, which is a positive floating point number directly followed by '`x`'.\n\nIf no descriptor is specified, the source is assigned the default descriptor: `1x`.\n\nIt is incorrect to mix width descriptors and pixel density descriptors in the same `srcset` attribute. Duplicate descriptors (for instance, two sources in the same `srcset` which are both described with '`2x`') are also invalid.\n\nThe user agent selects any one of the available sources at its discretion. This provides them with significant leeway to tailor their selection based on things like user preferences or bandwidth conditions. See our [Responsive images](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images) tutorial for an example."
+          },
+          "browsers": [
+            "C34",
+            "CA34",
+            "E12",
+            "FF38",
+            "FFA38",
+            "S8",
+            "SM8"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1504,6 +3268,20 @@
           "description": {
             "kind": "markdown",
             "value": "This enumerated attribute indicates if the fetching of the related image must be done using CORS or not. [CORS-enabled images](https://developer.mozilla.org/en-US/docs/CORS_Enabled_Image) can be reused in the [`<canvas>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas \"Use the HTML <canvas> element with either the canvas scripting API or the WebGL API to draw graphics and animations.\") element without being \"[tainted](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image#What_is_a_tainted_canvas).\" The allowed values are:\n`anonymous`\n\nA cross-origin request (i.e., with `Origin:` HTTP header) is performed, but no credential is sent (i.e., no cookie, X.509 certificate, or HTTP Basic authentication). If the server does not give credentials to the origin site (by not setting the [`Access-Control-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin \"The Access-Control-Allow-Origin response header indicates whether the response can be shared with requesting code from the given origin.\") HTTP header), the image will be tainted and its usage restricted.\n\n`use-credentials`\n\nA cross-origin request (i.e., with the [`Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin \"The Origin request header indicates where a fetch originates from. It doesn't include any path information, but only the server name. It is sent with CORS requests, as well as with POST requests. It is similar to the Referer header, but, unlike this header, it doesn't disclose the whole path.\") HTTP header) performed along with credentials sent (i.e., a cookie, certificate, or HTTP Basic authentication). If the server does not give credentials to the origin site (through the `Access-Control-Allow-Credentials` HTTP header), the image will be tainted and its usage restricted.\n\nIf the attribute is not present, the resource is fetched without a CORS request (i.e., without sending the `Origin` HTTP header), preventing its non-tainted usage in [`<canvas>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas \"Use the HTML <canvas> element with either the canvas scripting API or the WebGL API to draw graphics and animations.\") elements. If invalid, it is handled as if the `anonymous` value was used. See [CORS settings attributes](https://developer.mozilla.org/en-US/docs/HTML/CORS_settings_attributes) for additional information."
+          },
+          "browsers": [
+            "C13",
+            "CA18",
+            "E12",
+            "FF8",
+            "FFA8",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1511,6 +3289,20 @@
           "description": {
             "kind": "markdown",
             "value": "The partial URL (starting with '#') of an [image map](https://developer.mozilla.org/en-US/docs/HTML/Element/map) associated with the element.\n\n**Note:** You cannot use this attribute if the `<img>` element is a descendant of an [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a \"The HTML <a> element (or anchor element) creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL.\") or [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button \"The HTML <button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality.\") element."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1519,6 +3311,20 @@
           "description": {
             "kind": "markdown",
             "value": "This Boolean attribute indicates that the image is part of a server-side map. If so, the precise coordinates of a click are sent to the server.\n\n**Note:** This attribute is allowed only if the `<img>` element is a descendant of an [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a \"The HTML <a> element (or anchor element) creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL.\") element with a valid [`href`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href) attribute."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1526,6 +3332,20 @@
           "description": {
             "kind": "markdown",
             "value": "The intrinsic width of the image in pixels."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1533,6 +3353,20 @@
           "description": {
             "kind": "markdown",
             "value": "The intrinsic height of the image in pixels."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1541,6 +3375,20 @@
           "description": {
             "kind": "markdown",
             "value": "Provides an image decoding hint to the browser. The allowed values are:\n`sync`\n\nDecode the image synchronously for atomic presentation with other content.\n\n`async`\n\nDecode the image asynchronously to reduce delay in presenting other content.\n\n`auto`\n\nDefault mode, which indicates no preference for the decoding mode. The browser decides what is best for the user."
+          },
+          "browsers": [
+            "C65",
+            "CA65",
+            "E79",
+            "FF63",
+            "FFA63",
+            "S11.1",
+            "SM11.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "≤2020-01-15",
+            "baseline_high_date": "≤2022-07-15"
           }
         },
         {
@@ -1549,6 +3397,41 @@
           "description": {
             "kind": "markdown",
             "value": "Indicates how the browser should load the image."
+          },
+          "browsers": [
+            "C77",
+            "CA77",
+            "E79",
+            "FF75",
+            "FFA79",
+            "S15.4",
+            "SM15.4"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2022-03-14",
+            "baseline_high_date": "2024-09-14"
+          }
+        },
+        {
+          "name": "fetchpriority",
+          "valueSet": "fetchpriority",
+          "description": {
+            "kind": "markdown",
+            "value": "Provides a hint of the relative priority to use when fetching the image."
+          },
+          "browsers": [
+            "C101",
+            "CA101",
+            "E101",
+            "FF132",
+            "FFA132",
+            "S17.2",
+            "SM17.2"
+          ],
+          "status": {
+            "baseline": "low",
+            "baseline_low_date": "2024-10-29"
           }
         },
         {
@@ -1557,6 +3440,20 @@
           "description": {
             "kind": "markdown",
             "value": "A string indicating which referrer to use when fetching the resource:\n\n*   `no-referrer:` The [`Referer`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer \"The Referer request header contains the address of the previous web page from which a link to the currently requested page was followed. The Referer header allows servers to identify where people are visiting them from and may use that data for analytics, logging, or optimized caching, for example.\") header will not be sent.\n*   `no-referrer-when-downgrade:` No `Referer` header will be sent when navigating to an origin without TLS (HTTPS). This is a user agent’s default behavior if no policy is otherwise specified.\n*   `origin:` The `Referer` header will include the page of origin's scheme, the host, and the port.\n*   `origin-when-cross-origin:` Navigating to other origins will limit the included referral data to the scheme, the host and the port, while navigating from the same origin will include the referrer's full path.\n*   `unsafe-url:` The `Referer` header will include the origin and the path, but not the fragment, password, or username. This case is unsafe because it can leak origins and paths from TLS-protected resources to insecure origins."
+          },
+          "browsers": [
+            "C51",
+            "CA51",
+            "E79",
+            "FF50",
+            "FFA50",
+            "S14",
+            "SM14"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2020-09-16",
+            "baseline_high_date": "2023-03-16"
           }
         },
         {
@@ -1564,6 +3461,20 @@
           "description": {
             "kind": "markdown",
             "value": "A list of one or more strings separated by commas indicating a set of source sizes. Each source size consists of:\n\n1.  a media condition. This must be omitted for the last item.\n2.  a source size value.\n\nSource size values specify the intended display size of the image. User agents use the current source size to select one of the sources supplied by the `srcset` attribute, when those sources are described using width ('`w`') descriptors. The selected source size affects the intrinsic size of the image (the image’s display size if no CSS styling is applied). If the `srcset` attribute is absent, or contains no values with a width (`w`) descriptor, then the `sizes` attribute has no effect."
+          },
+          "browsers": [
+            "C38",
+            "CA38",
+            "E12",
+            "FF38",
+            "FFA38",
+            "S9.1",
+            "SM9.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2016-03-21",
+            "baseline_high_date": "2018-09-21"
           }
         },
         {
@@ -1584,7 +3495,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/img"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "iframe",
@@ -1598,6 +3523,20 @@
           "description": {
             "kind": "markdown",
             "value": "The URL of the page to embed. Use a value of `about:blank` to embed an empty page that conforms to the [same-origin policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#Inherited_origins). Also note that programatically removing an `<iframe>`'s src attribute (e.g. via [`Element.removeAttribute()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/removeAttribute \"The Element method removeAttribute() removes the attribute with the specified name from the element.\")) causes `about:blank` to be loaded in the frame in Firefox (from version 65), Chromium-based browsers, and Safari/iOS."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1605,6 +3544,20 @@
           "description": {
             "kind": "markdown",
             "value": "Inline HTML to embed, overriding the `src` attribute. If a browser does not support the `srcdoc` attribute, it will fall back to the URL in the `src` attribute."
+          },
+          "browsers": [
+            "C20",
+            "CA25",
+            "E79",
+            "FF25",
+            "FFA25",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2020-01-15",
+            "baseline_high_date": "2022-07-15"
           }
         },
         {
@@ -1612,6 +3565,20 @@
           "description": {
             "kind": "markdown",
             "value": "A targetable name for the embedded browsing context. This can be used in the `target` attribute of the [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a \"The HTML <a> element (or anchor element) creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL.\"), [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form \"The HTML <form> element represents a document section that contains interactive controls for submitting information to a web server.\"), or [`<base>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base \"The HTML <base> element specifies the base URL to use for all relative URLs contained within a document. There can be only one <base> element in a document.\") elements; the `formtarget` attribute of the [`<input>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input \"The HTML <input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent.\") or [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button \"The HTML <button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality.\") elements; or the `windowName` parameter in the [`window.open()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/open \"The Window interface's open() method loads the specified resource into the browsing context (window, <iframe> or tab) with the specified name. If the name doesn't exist, then a new window is opened and the specified resource is loaded into its browsing context.\") method."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1620,6 +3587,20 @@
           "description": {
             "kind": "markdown",
             "value": "Applies extra restrictions to the content in the frame. The value of the attribute can either be empty to apply all restrictions, or space-separated tokens to lift particular restrictions:\n\n*   `allow-forms`: Allows the resource to submit forms. If this keyword is not used, form submission is blocked.\n*   `allow-modals`: Lets the resource [open modal windows](https://html.spec.whatwg.org/multipage/origin.html#sandboxed-modals-flag).\n*   `allow-orientation-lock`: Lets the resource [lock the screen orientation](https://developer.mozilla.org/en-US/docs/Web/API/Screen/lockOrientation).\n*   `allow-pointer-lock`: Lets the resource use the [Pointer Lock API](https://developer.mozilla.org/en-US/docs/WebAPI/Pointer_Lock).\n*   `allow-popups`: Allows popups (such as `window.open()`, `target=\"_blank\"`, or `showModalDialog()`). If this keyword is not used, the popup will silently fail to open.\n*   `allow-popups-to-escape-sandbox`: Lets the sandboxed document open new windows without those windows inheriting the sandboxing. For example, this can safely sandbox an advertisement without forcing the same restrictions upon the page the ad links to.\n*   `allow-presentation`: Lets the resource start a [presentation session](https://developer.mozilla.org/en-US/docs/Web/API/PresentationRequest).\n*   `allow-same-origin`: If this token is not used, the resource is treated as being from a special origin that always fails the [same-origin policy](https://developer.mozilla.org/en-US/docs/Glossary/same-origin_policy \"same-origin policy: The same-origin policy is a critical security mechanism that restricts how a document or script loaded from one origin can interact with a resource from another origin.\").\n*   `allow-scripts`: Lets the resource run scripts (but not create popup windows).\n*   `allow-storage-access-by-user-activation` : Lets the resource request access to the parent's storage capabilities with the [Storage Access API](https://developer.mozilla.org/en-US/docs/Web/API/Storage_Access_API).\n*   `allow-top-navigation`: Lets the resource navigate the top-level browsing context (the one named `_top`).\n*   `allow-top-navigation-by-user-activation`: Lets the resource navigate the top-level browsing context, but only if initiated by a user gesture.\n\n**Notes about sandboxing:**\n\n*   When the embedded document has the same origin as the embedding page, it is **strongly discouraged** to use both `allow-scripts` and `allow-same-origin`, as that lets the embedded document remove the `sandbox` attribute — making it no more secure than not using the `sandbox` attribute at all.\n*   Sandboxing is useless if the attacker can display content outside a sandboxed `iframe` — such as if the viewer opens the frame in a new tab. Such content should be also served from a _separate origin_ to limit potential damage.\n*   The `sandbox` attribute is unsupported in Internet Explorer 9 and earlier."
+          },
+          "browsers": [
+            "C5",
+            "CA18",
+            "E12",
+            "FF17",
+            "FFA17",
+            "S5",
+            "SM4"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1632,6 +3613,17 @@
           "description": {
             "kind": "markdown",
             "value": "Set to `true` if the `<iframe>` can activate fullscreen mode by calling the [`requestFullscreen()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullscreen \"The Element.requestFullscreen() method issues an asynchronous request to make the element be displayed in full-screen mode.\") method.\nThis attribute is considered a legacy attribute and redefined as `allow=\"fullscreen\"`."
+          },
+          "browsers": [
+            "C38",
+            "CA38",
+            "E12",
+            "FF18",
+            "FFA18",
+            "S10.1"
+          ],
+          "status": {
+            "baseline": false
           }
         },
         {
@@ -1639,6 +3631,20 @@
           "description": {
             "kind": "markdown",
             "value": "The width of the frame in CSS pixels. Default is `300`."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1646,23 +3652,75 @@
           "description": {
             "kind": "markdown",
             "value": "The height of the frame in CSS pixels. Default is `150`."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
           "name": "allow",
-          "description": "Specifies a [feature policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy) for the `<iframe>`."
+          "description": "Specifies a [feature policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy) for the `<iframe>`.",
+          "browsers": [
+            "C60",
+            "CA60",
+            "E79",
+            "FF74",
+            "FFA79",
+            "S11.1",
+            "SM11.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2020-07-28",
+            "baseline_high_date": "2023-01-28"
+          }
         },
         {
           "name": "allowpaymentrequest",
-          "description": "Set to `true` if a cross-origin `<iframe>` should be allowed to invoke the [Payment Request API](https://developer.mozilla.org/en-US/docs/Web/API/Payment_Request_API)."
+          "description": "Set to `true` if a cross-origin `<iframe>` should be allowed to invoke the [Payment Request API](https://developer.mozilla.org/en-US/docs/Web/API/Payment_Request_API).",
+          "browsers": [
+            "C60",
+            "CA60",
+            "E79"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "allowpaymentrequest",
-          "description": "This attribute is considered a legacy attribute and redefined as `allow=\"payment\"`."
+          "description": "This attribute is considered a legacy attribute and redefined as `allow=\"payment\"`.",
+          "browsers": [
+            "C60",
+            "CA60",
+            "E79"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "csp",
-          "description": "A [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) enforced for the embedded resource. See [`HTMLIFrameElement.csp`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/csp \"The csp property of the HTMLIFrameElement interface specifies the Content Security Policy that an embedded document must agree to enforce upon itself.\") for details."
+          "description": "A [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) enforced for the embedded resource. See [`HTMLIFrameElement.csp`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/csp \"The csp property of the HTMLIFrameElement interface specifies the Content Security Policy that an embedded document must agree to enforce upon itself.\") for details.",
+          "browsers": [
+            "C61",
+            "CA61",
+            "E79"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "importance",
@@ -1670,7 +3728,21 @@
         },
         {
           "name": "referrerpolicy",
-          "description": "Indicates which [referrer](https://developer.mozilla.org/en-US/docs/Web/API/Document/referrer) to send when fetching the frame's resource:\n\n*   `no-referrer`: The [`Referer`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer \"The Referer request header contains the address of the previous web page from which a link to the currently requested page was followed. The Referer header allows servers to identify where people are visiting them from and may use that data for analytics, logging, or optimized caching, for example.\") header will not be sent.\n*   `no-referrer-when-downgrade` (default): The [`Referer`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer \"The Referer request header contains the address of the previous web page from which a link to the currently requested page was followed. The Referer header allows servers to identify where people are visiting them from and may use that data for analytics, logging, or optimized caching, for example.\") header will not be sent to [origin](https://developer.mozilla.org/en-US/docs/Glossary/origin \"origin: Web content's origin is defined by the scheme (protocol), host (domain), and port of the URL used to access it. Two objects have the same origin only when the scheme, host, and port all match.\")s without [TLS](https://developer.mozilla.org/en-US/docs/Glossary/TLS \"TLS: Transport Layer Security (TLS), previously known as Secure Sockets Layer (SSL), is a protocol used by applications to communicate securely across a network, preventing tampering with and eavesdropping on email, web browsing, messaging, and other protocols.\") ([HTTPS](https://developer.mozilla.org/en-US/docs/Glossary/HTTPS \"HTTPS: HTTPS (HTTP Secure) is an encrypted version of the HTTP protocol. It usually uses SSL or TLS to encrypt all communication between a client and a server. This secure connection allows clients to safely exchange sensitive data with a server, for example for banking activities or online shopping.\")).\n*   `origin`: The sent referrer will be limited to the origin of the referring page: its [scheme](https://developer.mozilla.org/en-US/docs/Archive/Mozilla/URIScheme), [host](https://developer.mozilla.org/en-US/docs/Glossary/host \"host: A host is a device connected to the Internet (or a local network). Some hosts called servers offer additional services like serving webpages or storing files and emails.\"), and [port](https://developer.mozilla.org/en-US/docs/Glossary/port \"port: For a computer connected to a network with an IP address, a port is a communication endpoint. Ports are designated by numbers, and below 1024 each port is associated by default with a specific protocol.\").\n*   `origin-when-cross-origin`: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path.\n*   `same-origin`: A referrer will be sent for [same origin](https://developer.mozilla.org/en-US/docs/Glossary/Same-origin_policy \"same origin: The same-origin policy is a critical security mechanism that restricts how a document or script loaded from one origin can interact with a resource from another origin.\"), but cross-origin requests will contain no referrer information.\n*   `strict-origin`: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP).\n*   `strict-origin-when-cross-origin`: Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP).\n*   `unsafe-url`: The referrer will include the origin _and_ the path (but not the [fragment](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/hash), [password](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/password), or [username](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/username)). **This value is unsafe**, because it leaks origins and paths from TLS-protected resources to insecure origins."
+          "description": "Indicates which [referrer](https://developer.mozilla.org/en-US/docs/Web/API/Document/referrer) to send when fetching the frame's resource:\n\n*   `no-referrer`: The [`Referer`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer \"The Referer request header contains the address of the previous web page from which a link to the currently requested page was followed. The Referer header allows servers to identify where people are visiting them from and may use that data for analytics, logging, or optimized caching, for example.\") header will not be sent.\n*   `no-referrer-when-downgrade` (default): The [`Referer`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer \"The Referer request header contains the address of the previous web page from which a link to the currently requested page was followed. The Referer header allows servers to identify where people are visiting them from and may use that data for analytics, logging, or optimized caching, for example.\") header will not be sent to [origin](https://developer.mozilla.org/en-US/docs/Glossary/origin \"origin: Web content's origin is defined by the scheme (protocol), host (domain), and port of the URL used to access it. Two objects have the same origin only when the scheme, host, and port all match.\")s without [TLS](https://developer.mozilla.org/en-US/docs/Glossary/TLS \"TLS: Transport Layer Security (TLS), previously known as Secure Sockets Layer (SSL), is a protocol used by applications to communicate securely across a network, preventing tampering with and eavesdropping on email, web browsing, messaging, and other protocols.\") ([HTTPS](https://developer.mozilla.org/en-US/docs/Glossary/HTTPS \"HTTPS: HTTPS (HTTP Secure) is an encrypted version of the HTTP protocol. It usually uses SSL or TLS to encrypt all communication between a client and a server. This secure connection allows clients to safely exchange sensitive data with a server, for example for banking activities or online shopping.\")).\n*   `origin`: The sent referrer will be limited to the origin of the referring page: its [scheme](https://developer.mozilla.org/en-US/docs/Archive/Mozilla/URIScheme), [host](https://developer.mozilla.org/en-US/docs/Glossary/host \"host: A host is a device connected to the Internet (or a local network). Some hosts called servers offer additional services like serving webpages or storing files and emails.\"), and [port](https://developer.mozilla.org/en-US/docs/Glossary/port \"port: For a computer connected to a network with an IP address, a port is a communication endpoint. Ports are designated by numbers, and below 1024 each port is associated by default with a specific protocol.\").\n*   `origin-when-cross-origin`: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path.\n*   `same-origin`: A referrer will be sent for [same origin](https://developer.mozilla.org/en-US/docs/Glossary/Same-origin_policy \"same origin: The same-origin policy is a critical security mechanism that restricts how a document or script loaded from one origin can interact with a resource from another origin.\"), but cross-origin requests will contain no referrer information.\n*   `strict-origin`: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP).\n*   `strict-origin-when-cross-origin`: Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP).\n*   `unsafe-url`: The referrer will include the origin _and_ the path (but not the [fragment](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/hash), [password](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/password), or [username](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/username)). **This value is unsafe**, because it leaks origins and paths from TLS-protected resources to insecure origins.",
+          "browsers": [
+            "C51",
+            "CA51",
+            "E79",
+            "FF50",
+            "FFA50",
+            "S14",
+            "SM14"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2020-09-16",
+            "baseline_high_date": "2023-03-16"
+          }
         }
       ],
       "references": [
@@ -1678,7 +3750,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/iframe"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "embed",
@@ -1693,6 +3779,20 @@
           "description": {
             "kind": "markdown",
             "value": "The URL of the resource being embedded."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1700,6 +3800,20 @@
           "description": {
             "kind": "markdown",
             "value": "The MIME type to use to select the plug-in to instantiate."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E79",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2020-01-15",
+            "baseline_high_date": "2022-07-15"
           }
         },
         {
@@ -1707,6 +3821,20 @@
           "description": {
             "kind": "markdown",
             "value": "The displayed width of the resource, in [CSS pixels](https://drafts.csswg.org/css-values/#px). This must be an absolute value; percentages are _not_ allowed."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1714,6 +3842,20 @@
           "description": {
             "kind": "markdown",
             "value": "The displayed height of the resource, in [CSS pixels](https://drafts.csswg.org/css-values/#px). This must be an absolute value; percentages are _not_ allowed."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         }
       ],
@@ -1722,7 +3864,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/embed"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "object",
@@ -1736,6 +3892,20 @@
           "description": {
             "kind": "markdown",
             "value": "The address of the resource as a valid URL. At least one of **data** and **type** must be defined."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1743,6 +3913,20 @@
           "description": {
             "kind": "markdown",
             "value": "The [content type](https://developer.mozilla.org/en-US/docs/Glossary/Content_type) of the resource specified by **data**. At least one of **data** and **type** must be defined."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1758,6 +3942,20 @@
           "description": {
             "kind": "markdown",
             "value": "The name of valid browsing context (HTML5), or the name of the control (HTML 4)."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1765,6 +3963,18 @@
           "description": {
             "kind": "markdown",
             "value": "A hash-name reference to a [`<map>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map \"The HTML <map> element is used with <area> elements to define an image map (a clickable link area).\") element; that is a '#' followed by the value of a [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map#attr-name) of a map element."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": false
           }
         },
         {
@@ -1772,6 +3982,20 @@
           "description": {
             "kind": "markdown",
             "value": "The form element, if any, that the object element is associated with (its _form owner_). The value of the attribute must be an ID of a [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form \"The HTML <form> element represents a document section that contains interactive controls for submitting information to a web server.\") element in the same document."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1779,6 +4003,20 @@
           "description": {
             "kind": "markdown",
             "value": "The width of the display resource, in [CSS pixels](https://drafts.csswg.org/css-values/#px). -- (Absolute values only. [NO percentages](https://html.spec.whatwg.org/multipage/embedded-content.html#dimension-attributes))"
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1786,35 +4024,133 @@
           "description": {
             "kind": "markdown",
             "value": "The height of the displayed resource, in [CSS pixels](https://drafts.csswg.org/css-values/#px). -- (Absolute values only. [NO percentages](https://html.spec.whatwg.org/multipage/embedded-content.html#dimension-attributes))"
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
           "name": "archive",
-          "description": "A space-separated list of URIs for archives of resources for the object."
+          "description": "A space-separated list of URIs for archives of resources for the object.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "border",
-          "description": "The width of a border around the control, in pixels."
+          "description": "The width of a border around the control, in pixels.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "classid",
-          "description": "The URI of the object's implementation. It can be used together with, or in place of, the **data** attribute."
+          "description": "The URI of the object's implementation. It can be used together with, or in place of, the **data** attribute.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "codebase",
-          "description": "The base path used to resolve relative URIs specified by **classid**, **data**, or **archive**. If not specified, the default is the base URI of the current document."
+          "description": "The base path used to resolve relative URIs specified by **classid**, **data**, or **archive**. If not specified, the default is the base URI of the current document.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "codetype",
-          "description": "The content type of the data specified by **classid**."
+          "description": "The content type of the data specified by **classid**.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "declare",
-          "description": "The presence of this Boolean attribute makes this element a declaration only. The object must be instantiated by a subsequent `<object>` element. In HTML5, repeat the <object> element completely each that that the resource is reused."
+          "description": "The presence of this Boolean attribute makes this element a declaration only. The object must be instantiated by a subsequent `<object>` element. In HTML5, repeat the <object> element completely each that that the resource is reused.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "standby",
-          "description": "A message that the browser can show while loading the object's implementation and data."
+          "description": "A message that the browser can show while loading the object's implementation and data.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "tabindex",
@@ -1826,7 +4162,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/object"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S3",
+        "SM2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "param",
@@ -1874,18 +4224,74 @@
       },
       "attributes": [
         {
-          "name": "src"
+          "name": "src",
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF3.5",
+            "FFA4",
+            "S3.1",
+            "SM3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "crossorigin",
-          "valueSet": "xo"
+          "valueSet": "xo",
+          "browsers": [
+            "C33",
+            "CA33",
+            "E18",
+            "FF74",
+            "FFA79",
+            "S10",
+            "SM10"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2020-07-28",
+            "baseline_high_date": "2023-01-28"
+          }
         },
         {
-          "name": "poster"
+          "name": "poster",
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF3.6",
+            "FFA4",
+            "S3.1",
+            "SM3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "preload",
-          "valueSet": "pl"
+          "valueSet": "pl",
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S3.1",
+            "SM3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "autoplay",
@@ -1893,6 +4299,20 @@
           "description": {
             "kind": "markdown",
             "value": "A Boolean attribute; if specified, the video automatically begins to play back as soon as it can do so without stopping to finish loading the data.\n**Note**: Sites that automatically play audio (or video with an audio track) can be an unpleasant experience for users, so it should be avoided when possible. If you must offer autoplay functionality, you should make it opt-in (requiring a user to specifically enable it). However, this can be useful when creating media elements whose source will be set at a later time, under user control.\n\nTo disable video autoplay, `autoplay=\"false\"` will not work; the video will autoplay if the attribute is there in the `<video>` tag at all. To remove autoplay the attribute needs to be removed altogether.\n\nIn some browsers (e.g. Chrome 70.0) autoplay is not working if no `muted` attribute is present."
+          },
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF3.5",
+            "FFA4",
+            "S3.1",
+            "SM10"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2016-09-13",
+            "baseline_high_date": "2019-03-13"
           }
         },
         {
@@ -1900,21 +4320,91 @@
         },
         {
           "name": "loop",
-          "valueSet": "v"
+          "valueSet": "v",
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF11",
+            "FFA14",
+            "S3.1",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "muted",
-          "valueSet": "v"
+          "valueSet": "v",
+          "browsers": [
+            "C30",
+            "CA30",
+            "E12",
+            "FF11",
+            "FFA14",
+            "S5",
+            "SM4.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "controls",
-          "valueSet": "v"
+          "valueSet": "v",
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF3.5",
+            "FFA4",
+            "S3.1",
+            "SM3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "width"
+          "name": "width",
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF3.5",
+            "FFA4",
+            "S3.1",
+            "SM3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "height"
+          "name": "height",
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF3.5",
+            "FFA4",
+            "S3.1",
+            "SM3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         }
       ],
       "references": [
@@ -1922,7 +4412,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/video"
         }
-      ]
+      ],
+      "browsers": [
+        "C3",
+        "CA18",
+        "E12",
+        "FF3.5",
+        "FFA4",
+        "S3.1",
+        "SM3"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "audio",
@@ -1936,6 +4440,20 @@
           "description": {
             "kind": "markdown",
             "value": "The URL of the audio to embed. This is subject to [HTTP access controls](https://developer.mozilla.org/en-US/docs/HTTP_access_control). This is optional; you may instead use the [`<source>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source \"The HTML <source> element specifies multiple media resources for the <picture>, the <audio> element, or the <video> element.\") element within the audio block to specify the audio to embed."
+          },
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF3.5",
+            "FFA4",
+            "S3.1",
+            "SM3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1944,6 +4462,20 @@
           "description": {
             "kind": "markdown",
             "value": "This enumerated attribute indicates whether to use CORS to fetch the related image. [CORS-enabled resources](https://developer.mozilla.org/en-US/docs/CORS_Enabled_Image) can be reused in the [`<canvas>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas \"Use the HTML <canvas> element with either the canvas scripting API or the WebGL API to draw graphics and animations.\") element without being _tainted_. The allowed values are:\n\nanonymous\n\nSends a cross-origin request without a credential. In other words, it sends the `Origin:` HTTP header without a cookie, X.509 certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (by not setting the `Access-Control-Allow-Origin:` HTTP header), the image will be _tainted_, and its usage restricted.\n\nuse-credentials\n\nSends a cross-origin request with a credential. In other words, it sends the `Origin:` HTTP header with a cookie, a certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (through `Access-Control-Allow-Credentials:` HTTP header), the image will be _tainted_ and its usage restricted.\n\nWhen not present, the resource is fetched without a CORS request (i.e. without sending the `Origin:` HTTP header), preventing its non-tainted used in [`<canvas>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas \"Use the HTML <canvas> element with either the canvas scripting API or the WebGL API to draw graphics and animations.\") elements. If invalid, it is handled as if the enumerated keyword **anonymous** was used. See [CORS settings attributes](https://developer.mozilla.org/en-US/docs/HTML/CORS_settings_attributes) for additional information."
+          },
+          "browsers": [
+            "C33",
+            "CA33",
+            "E18",
+            "FF74",
+            "FFA79",
+            "S10",
+            "SM10"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2020-07-28",
+            "baseline_high_date": "2023-01-28"
           }
         },
         {
@@ -1952,6 +4484,20 @@
           "description": {
             "kind": "markdown",
             "value": "This enumerated attribute is intended to provide a hint to the browser about what the author thinks will lead to the best user experience. It may have one of the following values:\n\n*   `none`: Indicates that the audio should not be preloaded.\n*   `metadata`: Indicates that only audio metadata (e.g. length) is fetched.\n*   `auto`: Indicates that the whole audio file can be downloaded, even if the user is not expected to use it.\n*   _empty string_: A synonym of the `auto` value.\n\nIf not set, `preload`'s default value is browser-defined (i.e. each browser may have its own default value). The spec advises it to be set to `metadata`.\n\n**Usage notes:**\n\n*   The `autoplay` attribute has precedence over `preload`. If `autoplay` is specified, the browser would obviously need to start downloading the audio for playback.\n*   The browser is not forced by the specification to follow the value of this attribute; it is a mere hint."
+          },
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S3.1",
+            "SM3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1960,6 +4506,10 @@
           "description": {
             "kind": "markdown",
             "value": "A Boolean attribute: if specified, the audio will automatically begin playback as soon as it can do so, without waiting for the entire audio file to finish downloading.\n\n**Note**: Sites that automatically play audio (or videos with an audio track) can be an unpleasant experience for users, so should be avoided when possible. If you must offer autoplay functionality, you should make it opt-in (requiring a user to specifically enable it). However, this can be useful when creating media elements whose source will be set at a later time, under user control."
+          },
+          "browsers": [],
+          "status": {
+            "baseline": false
           }
         },
         {
@@ -1971,6 +4521,20 @@
           "description": {
             "kind": "markdown",
             "value": "A Boolean attribute: if specified, the audio player will automatically seek back to the start upon reaching the end of the audio."
+          },
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF11",
+            "FFA14",
+            "S3.1",
+            "SM3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -1979,6 +4543,20 @@
           "description": {
             "kind": "markdown",
             "value": "A Boolean attribute that indicates whether the audio will be initially silenced. Its default value is `false`."
+          },
+          "browsers": [
+            "C15",
+            "CA18",
+            "E18",
+            "FF11",
+            "FFA14",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "≤2018-10-02",
+            "baseline_high_date": "≤2021-04-02"
           }
         },
         {
@@ -1987,6 +4565,20 @@
           "description": {
             "kind": "markdown",
             "value": "If this attribute is present, the browser will offer controls to allow the user to control audio playback, including volume, seeking, and pause/resume playback."
+          },
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF3.5",
+            "FFA4",
+            "S3.1",
+            "SM3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         }
       ],
@@ -1995,7 +4587,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/audio"
         }
-      ]
+      ],
+      "browsers": [
+        "C3",
+        "CA18",
+        "E12",
+        "FF3.5",
+        "FFA4",
+        "S3.1",
+        "SM3"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "source",
@@ -2010,6 +4616,20 @@
           "description": {
             "kind": "markdown",
             "value": "Required for [`<audio>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio \"The HTML <audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the <source> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream.\") and [`<video>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video \"The HTML Video element (<video>) embeds a media player which supports video playback into the document.\"), address of the media resource. The value of this attribute is ignored when the `<source>` element is placed inside a [`<picture>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture \"The HTML <picture> element contains zero or more <source> elements and one <img> element to provide versions of an image for different display/device scenarios.\") element."
+          },
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF3.5",
+            "FFA4",
+            "S3.1",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2017,19 +4637,75 @@
           "description": {
             "kind": "markdown",
             "value": "The MIME-type of the resource, optionally with a `codecs` parameter. See [RFC 4281](https://tools.ietf.org/html/rfc4281) for information about how to specify codecs."
+          },
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF3.5",
+            "FFA4",
+            "S3.1",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
           "name": "sizes",
-          "description": "Is a list of source sizes that describes the final rendered width of the image represented by the source. Each source size consists of a comma-separated list of media condition-length pairs. This information is used by the browser to determine, before laying the page out, which image defined in [`srcset`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source#attr-srcset) to use.  \nThe `sizes` attribute has an effect only when the [`<source>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source \"The HTML <source> element specifies multiple media resources for the <picture>, the <audio> element, or the <video> element.\") element is the direct child of a [`<picture>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture \"The HTML <picture> element contains zero or more <source> elements and one <img> element to provide versions of an image for different display/device scenarios.\") element."
+          "description": "Is a list of source sizes that describes the final rendered width of the image represented by the source. Each source size consists of a comma-separated list of media condition-length pairs. This information is used by the browser to determine, before laying the page out, which image defined in [`srcset`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source#attr-srcset) to use.  \nThe `sizes` attribute has an effect only when the [`<source>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source \"The HTML <source> element specifies multiple media resources for the <picture>, the <audio> element, or the <video> element.\") element is the direct child of a [`<picture>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture \"The HTML <picture> element contains zero or more <source> elements and one <img> element to provide versions of an image for different display/device scenarios.\") element.",
+          "browsers": [
+            "C34",
+            "CA34",
+            "E13",
+            "FF38",
+            "FFA38",
+            "S9.1",
+            "SM9.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2016-03-21",
+            "baseline_high_date": "2018-09-21"
+          }
         },
         {
           "name": "srcset",
-          "description": "A list of one or more strings separated by commas indicating a set of possible images represented by the source for the browser to use. Each string is composed of:\n\n1.  one URL to an image,\n2.  a width descriptor, that is a positive integer directly followed by `'w'`. The default value, if missing, is the infinity.\n3.  a pixel density descriptor, that is a positive floating number directly followed by `'x'`. The default value, if missing, is `1x`.\n\nEach string in the list must have at least a width descriptor or a pixel density descriptor to be valid. Among the list, there must be only one string containing the same tuple of width descriptor and pixel density descriptor.  \nThe browser chooses the most adequate image to display at a given point of time.  \nThe `srcset` attribute has an effect only when the [`<source>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source \"The HTML <source> element specifies multiple media resources for the <picture>, the <audio> element, or the <video> element.\") element is the direct child of a [`<picture>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture \"The HTML <picture> element contains zero or more <source> elements and one <img> element to provide versions of an image for different display/device scenarios.\") element."
+          "description": "A list of one or more strings separated by commas indicating a set of possible images represented by the source for the browser to use. Each string is composed of:\n\n1.  one URL to an image,\n2.  a width descriptor, that is a positive integer directly followed by `'w'`. The default value, if missing, is the infinity.\n3.  a pixel density descriptor, that is a positive floating number directly followed by `'x'`. The default value, if missing, is `1x`.\n\nEach string in the list must have at least a width descriptor or a pixel density descriptor to be valid. Among the list, there must be only one string containing the same tuple of width descriptor and pixel density descriptor.  \nThe browser chooses the most adequate image to display at a given point of time.  \nThe `srcset` attribute has an effect only when the [`<source>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source \"The HTML <source> element specifies multiple media resources for the <picture>, the <audio> element, or the <video> element.\") element is the direct child of a [`<picture>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture \"The HTML <picture> element contains zero or more <source> elements and one <img> element to provide versions of an image for different display/device scenarios.\") element.",
+          "browsers": [
+            "C34",
+            "CA34",
+            "E13",
+            "FF38",
+            "FFA38",
+            "S9.1",
+            "SM9.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2016-03-21",
+            "baseline_high_date": "2018-09-21"
+          }
         },
         {
           "name": "media",
-          "description": "[Media query](https://developer.mozilla.org/en-US/docs/CSS/Media_queries) of the resource's intended media; this should be used only in a [`<picture>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture \"The HTML <picture> element contains zero or more <source> elements and one <img> element to provide versions of an image for different display/device scenarios.\") element."
+          "description": "[Media query](https://developer.mozilla.org/en-US/docs/CSS/Media_queries) of the resource's intended media; this should be used only in a [`<picture>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture \"The HTML <picture> element contains zero or more <source> elements and one <img> element to provide versions of an image for different display/device scenarios.\") element.",
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF15",
+            "FFA15",
+            "S3.1",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         }
       ],
       "references": [
@@ -2037,7 +4713,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/source"
         }
-      ]
+      ],
+      "browsers": [
+        "C3",
+        "CA18",
+        "E12",
+        "FF3.5",
+        "FFA4",
+        "S3.1",
+        "SM2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "track",
@@ -2053,6 +4743,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute indicates that the track should be enabled unless the user's preferences indicate that another track is more appropriate. This may only be used on one `track` element per media element."
+          },
+          "browsers": [
+            "C23",
+            "CA25",
+            "E12",
+            "FF31",
+            "FFA31",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2061,6 +4765,20 @@
           "description": {
             "kind": "markdown",
             "value": "How the text track is meant to be used. If omitted the default kind is `subtitles`. If the attribute is not present, it will use the `subtitles`. If the attribute contains an invalid value, it will use `metadata`. (Versions of Chrome earlier than 52 treated an invalid value as `subtitles`.) The following keywords are allowed:\n\n*   `subtitles`\n    *   Subtitles provide translation of content that cannot be understood by the viewer. For example dialogue or text that is not English in an English language film.\n    *   Subtitles may contain additional content, usually extra background information. For example the text at the beginning of the Star Wars films, or the date, time, and location of a scene.\n*   `captions`\n    *   Closed captions provide a transcription and possibly a translation of audio.\n    *   It may include important non-verbal information such as music cues or sound effects. It may indicate the cue's source (e.g. music, text, character).\n    *   Suitable for users who are deaf or when the sound is muted.\n*   `descriptions`\n    *   Textual description of the video content.\n    *   Suitable for users who are blind or where the video cannot be seen.\n*   `chapters`\n    *   Chapter titles are intended to be used when the user is navigating the media resource.\n*   `metadata`\n    *   Tracks used by scripts. Not visible to the user."
+          },
+          "browsers": [
+            "C23",
+            "CA25",
+            "E12",
+            "FF31",
+            "FFA31",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2068,6 +4786,20 @@
           "description": {
             "kind": "markdown",
             "value": "A user-readable title of the text track which is used by the browser when listing available text tracks."
+          },
+          "browsers": [
+            "C23",
+            "CA25",
+            "E12",
+            "FF31",
+            "FFA31",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2075,6 +4807,20 @@
           "description": {
             "kind": "markdown",
             "value": "Address of the track (`.vtt` file). Must be a valid URL. This attribute must be specified and its URL value must have the same origin as the document — unless the [`<audio>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio \"The HTML <audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the <source> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream.\") or [`<video>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video \"The HTML Video element (<video>) embeds a media player which supports video playback into the document.\") parent element of the `track` element has a [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) attribute."
+          },
+          "browsers": [
+            "C23",
+            "CA25",
+            "E12",
+            "FF50",
+            "FFA50",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2016-11-15",
+            "baseline_high_date": "2019-05-15"
           }
         },
         {
@@ -2082,6 +4828,20 @@
           "description": {
             "kind": "markdown",
             "value": "Language of the track text data. It must be a valid [BCP 47](https://r12a.github.io/app-subtags/) language tag. If the `kind` attribute is set to `subtitles,` then `srclang` must be defined."
+          },
+          "browsers": [
+            "C23",
+            "CA25",
+            "E12",
+            "FF31",
+            "FFA31",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         }
       ],
@@ -2090,7 +4850,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/track"
         }
-      ]
+      ],
+      "browsers": [
+        "C23",
+        "CA25",
+        "E12",
+        "FF31",
+        "FFA31",
+        "S6",
+        "SM6"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "map",
@@ -2104,6 +4878,20 @@
           "description": {
             "kind": "markdown",
             "value": "The name attribute gives the map a name so that it can be referenced. The attribute must be present and must have a non-empty value with no space characters. The value of the name attribute must not be a compatibility-caseless match for the value of the name attribute of another map element in the same document. If the id attribute is also specified, both attributes must have the same value."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         }
       ],
@@ -2112,7 +4900,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/map"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "area",
@@ -2123,30 +4925,138 @@
       "void": true,
       "attributes": [
         {
-          "name": "alt"
+          "name": "alt",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "coords"
+          "name": "coords",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "shape",
-          "valueSet": "sh"
+          "valueSet": "sh",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "href"
+          "name": "href",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "target",
-          "valueSet": "target"
+          "valueSet": "target",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "download"
+          "name": "download",
+          "browsers": [
+            "C54",
+            "CA54",
+            "E12",
+            "FF20",
+            "FFA20",
+            "S10.1",
+            "SM10.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2017-03-27",
+            "baseline_high_date": "2019-09-27"
+          }
         },
         {
-          "name": "ping"
+          "name": "ping",
+          "browsers": [
+            "C12",
+            "CA18",
+            "E17",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
-          "name": "rel"
+          "name": "rel",
+          "browsers": [
+            "C16",
+            "CA18",
+            "E12",
+            "FF30",
+            "FFA30",
+            "S5",
+            "SM4.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "hreflang"
@@ -2164,7 +5074,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/area"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "table",
@@ -2174,11 +5098,35 @@
       },
       "attributes": [
         {
-          "name": "border"
+          "name": "border",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "align",
-          "description": "This enumerated attribute indicates how the table must be aligned inside the containing document. It may have the following values:\n\n*   left: the table is displayed on the left side of the document;\n*   center: the table is displayed in the center of the document;\n*   right: the table is displayed on the right side of the document.\n\n**Usage Note**\n\n*   **Do not use this attribute**, as it has been deprecated. The [`<table>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table \"The HTML <table> element represents tabular data — that is, information presented in a two-dimensional table comprised of rows and columns of cells containing data.\") element should be styled using [CSS](https://developer.mozilla.org/en-US/docs/CSS). Set [`margin-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-left \"The margin-left CSS property sets the margin area on the left side of an element. A positive value places it farther from its neighbors, while a negative value places it closer.\") and [`margin-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-right \"The margin-right CSS property sets the margin area on the right side of an element. A positive value places it farther from its neighbors, while a negative value places it closer.\") to `auto` or [`margin`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin \"The margin CSS property sets the margin area on all four sides of an element. It is a shorthand for margin-top, margin-right, margin-bottom, and margin-left.\") to `0 auto` to achieve an effect that is similar to the align attribute.\n*   Prior to Firefox 4, Firefox also supported the `middle`, `absmiddle`, and `abscenter` values as synonyms of `center`, in quirks mode only."
+          "description": "This enumerated attribute indicates how the table must be aligned inside the containing document. It may have the following values:\n\n*   left: the table is displayed on the left side of the document;\n*   center: the table is displayed in the center of the document;\n*   right: the table is displayed on the right side of the document.\n\n**Usage Note**\n\n*   **Do not use this attribute**, as it has been deprecated. The [`<table>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table \"The HTML <table> element represents tabular data — that is, information presented in a two-dimensional table comprised of rows and columns of cells containing data.\") element should be styled using [CSS](https://developer.mozilla.org/en-US/docs/CSS). Set [`margin-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-left \"The margin-left CSS property sets the margin area on the left side of an element. A positive value places it farther from its neighbors, while a negative value places it closer.\") and [`margin-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-right \"The margin-right CSS property sets the margin area on the right side of an element. A positive value places it farther from its neighbors, while a negative value places it closer.\") to `auto` or [`margin`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin \"The margin CSS property sets the margin area on all four sides of an element. It is a shorthand for margin-top, margin-right, margin-bottom, and margin-left.\") to `0 auto` to achieve an effect that is similar to the align attribute.\n*   Prior to Firefox 4, Firefox also supported the `middle`, `absmiddle`, and `abscenter` values as synonyms of `center`, in quirks mode only.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -2186,7 +5134,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/table"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "caption",
@@ -2197,7 +5159,19 @@
       "attributes": [
         {
           "name": "align",
-          "description": "This enumerated attribute indicates how the caption must be aligned with respect to the table. It may have one of the following values:\n\n`left`\n\nThe caption is displayed to the left of the table.\n\n`top`\n\nThe caption is displayed above the table.\n\n`right`\n\nThe caption is displayed to the right of the table.\n\n`bottom`\n\nThe caption is displayed below the table.\n\n**Usage note:** Do not use this attribute, as it has been deprecated. The [`<caption>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption \"The HTML Table Caption element (<caption>) specifies the caption (or title) of a table, and if used is always the first child of a <table>.\") element should be styled using the [CSS](https://developer.mozilla.org/en-US/docs/CSS) properties [`caption-side`](https://developer.mozilla.org/en-US/docs/Web/CSS/caption-side \"The caption-side CSS property puts the content of a table's <caption> on the specified side. The values are relative to the writing-mode of the table.\") and [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\")."
+          "description": "This enumerated attribute indicates how the caption must be aligned with respect to the table. It may have one of the following values:\n\n`left`\n\nThe caption is displayed to the left of the table.\n\n`top`\n\nThe caption is displayed above the table.\n\n`right`\n\nThe caption is displayed to the right of the table.\n\n`bottom`\n\nThe caption is displayed below the table.\n\n**Usage note:** Do not use this attribute, as it has been deprecated. The [`<caption>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption \"The HTML Table Caption element (<caption>) specifies the caption (or title) of a table, and if used is always the first child of a <table>.\") element should be styled using the [CSS](https://developer.mozilla.org/en-US/docs/CSS) properties [`caption-side`](https://developer.mozilla.org/en-US/docs/Web/CSS/caption-side \"The caption-side CSS property puts the content of a table's <caption> on the specified side. The values are relative to the writing-mode of the table.\") and [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\").",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -2205,7 +5179,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/caption"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "colgroup",
@@ -2215,11 +5203,37 @@
       },
       "attributes": [
         {
-          "name": "span"
+          "name": "span",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "align",
-          "description": "This enumerated attribute specifies how horizontal alignment of each column cell content will be handled. Possible values are:\n\n*   `left`, aligning the content to the left of the cell\n*   `center`, centering the content in the cell\n*   `right`, aligning the content to the right of the cell\n*   `justify`, inserting spaces into the textual content so that the content is justified in the cell\n*   `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col#attr-charoff) attributes Unimplemented (see [bug 2212](https://bugzilla.mozilla.org/show_bug.cgi?id=2212 \"character alignment not implemented (align=char, charoff=, text-align:<string>)\")).\n\nIf this attribute is not set, the `left` value is assumed. The descendant [`<col>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col \"The HTML <col> element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a <colgroup> element.\") elements may override this value using their own [`align`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col#attr-align) attribute.\n\n**Note:** Do not use this attribute as it is obsolete (not supported) in the latest standard.\n\n*   To achieve the same effect as the `left`, `center`, `right` or `justify` values:\n    *   Do not try to set the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property on a selector giving a [`<colgroup>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup \"The HTML <colgroup> element defines a group of columns within a table.\") element. Because [`<td>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td \"The HTML <td> element defines a cell of a table that contains data. It participates in the table model.\") elements are not descendant of the [`<colgroup>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup \"The HTML <colgroup> element defines a group of columns within a table.\") element, they won't inherit it.\n    *   If the table doesn't use a [`colspan`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-colspan) attribute, use one `td:nth-child(an+b)` CSS selector per column, where a is the total number of the columns in the table and b is the ordinal position of this column in the table. Only after this selector the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property can be used.\n    *   If the table does use a [`colspan`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-colspan) attribute, the effect can be achieved by combining adequate CSS attribute selectors like `[colspan=n]`, though this is not trivial.\n*   To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup#attr-char) as the value of the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property Unimplemented."
+          "description": "This enumerated attribute specifies how horizontal alignment of each column cell content will be handled. Possible values are:\n\n*   `left`, aligning the content to the left of the cell\n*   `center`, centering the content in the cell\n*   `right`, aligning the content to the right of the cell\n*   `justify`, inserting spaces into the textual content so that the content is justified in the cell\n*   `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col#attr-charoff) attributes Unimplemented (see [bug 2212](https://bugzilla.mozilla.org/show_bug.cgi?id=2212 \"character alignment not implemented (align=char, charoff=, text-align:<string>)\")).\n\nIf this attribute is not set, the `left` value is assumed. The descendant [`<col>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col \"The HTML <col> element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a <colgroup> element.\") elements may override this value using their own [`align`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col#attr-align) attribute.\n\n**Note:** Do not use this attribute as it is obsolete (not supported) in the latest standard.\n\n*   To achieve the same effect as the `left`, `center`, `right` or `justify` values:\n    *   Do not try to set the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property on a selector giving a [`<colgroup>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup \"The HTML <colgroup> element defines a group of columns within a table.\") element. Because [`<td>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td \"The HTML <td> element defines a cell of a table that contains data. It participates in the table model.\") elements are not descendant of the [`<colgroup>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup \"The HTML <colgroup> element defines a group of columns within a table.\") element, they won't inherit it.\n    *   If the table doesn't use a [`colspan`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-colspan) attribute, use one `td:nth-child(an+b)` CSS selector per column, where a is the total number of the columns in the table and b is the ordinal position of this column in the table. Only after this selector the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property can be used.\n    *   If the table does use a [`colspan`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-colspan) attribute, the effect can be achieved by combining adequate CSS attribute selectors like `[colspan=n]`, though this is not trivial.\n*   To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup#attr-char) as the value of the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property Unimplemented.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -2227,7 +5241,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/colgroup"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "col",
@@ -2238,11 +5266,37 @@
       "void": true,
       "attributes": [
         {
-          "name": "span"
+          "name": "span",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "align",
-          "description": "This enumerated attribute specifies how horizontal alignment of each column cell content will be handled. Possible values are:\n\n*   `left`, aligning the content to the left of the cell\n*   `center`, centering the content in the cell\n*   `right`, aligning the content to the right of the cell\n*   `justify`, inserting spaces into the textual content so that the content is justified in the cell\n*   `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col#attr-charoff) attributes Unimplemented (see [bug 2212](https://bugzilla.mozilla.org/show_bug.cgi?id=2212 \"character alignment not implemented (align=char, charoff=, text-align:<string>)\")).\n\nIf this attribute is not set, its value is inherited from the [`align`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup#attr-align) of the [`<colgroup>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup \"The HTML <colgroup> element defines a group of columns within a table.\") element this `<col>` element belongs too. If there are none, the `left` value is assumed.\n\n**Note:** Do not use this attribute as it is obsolete (not supported) in the latest standard.\n\n*   To achieve the same effect as the `left`, `center`, `right` or `justify` values:\n    *   Do not try to set the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property on a selector giving a [`<col>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col \"The HTML <col> element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a <colgroup> element.\") element. Because [`<td>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td \"The HTML <td> element defines a cell of a table that contains data. It participates in the table model.\") elements are not descendant of the [`<col>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col \"The HTML <col> element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a <colgroup> element.\") element, they won't inherit it.\n    *   If the table doesn't use a [`colspan`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-colspan) attribute, use the `td:nth-child(an+b)` CSS selector. Set `a` to zero and `b` to the position of the column in the table, e.g. `td:nth-child(2) { text-align: right; }` to right-align the second column.\n    *   If the table does use a [`colspan`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-colspan) attribute, the effect can be achieved by combining adequate CSS attribute selectors like `[colspan=n]`, though this is not trivial.\n*   To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col#attr-char) as the value of the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property Unimplemented."
+          "description": "This enumerated attribute specifies how horizontal alignment of each column cell content will be handled. Possible values are:\n\n*   `left`, aligning the content to the left of the cell\n*   `center`, centering the content in the cell\n*   `right`, aligning the content to the right of the cell\n*   `justify`, inserting spaces into the textual content so that the content is justified in the cell\n*   `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col#attr-charoff) attributes Unimplemented (see [bug 2212](https://bugzilla.mozilla.org/show_bug.cgi?id=2212 \"character alignment not implemented (align=char, charoff=, text-align:<string>)\")).\n\nIf this attribute is not set, its value is inherited from the [`align`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup#attr-align) of the [`<colgroup>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup \"The HTML <colgroup> element defines a group of columns within a table.\") element this `<col>` element belongs too. If there are none, the `left` value is assumed.\n\n**Note:** Do not use this attribute as it is obsolete (not supported) in the latest standard.\n\n*   To achieve the same effect as the `left`, `center`, `right` or `justify` values:\n    *   Do not try to set the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property on a selector giving a [`<col>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col \"The HTML <col> element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a <colgroup> element.\") element. Because [`<td>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td \"The HTML <td> element defines a cell of a table that contains data. It participates in the table model.\") elements are not descendant of the [`<col>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col \"The HTML <col> element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a <colgroup> element.\") element, they won't inherit it.\n    *   If the table doesn't use a [`colspan`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-colspan) attribute, use the `td:nth-child(an+b)` CSS selector. Set `a` to zero and `b` to the position of the column in the table, e.g. `td:nth-child(2) { text-align: right; }` to right-align the second column.\n    *   If the table does use a [`colspan`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-colspan) attribute, the effect can be achieved by combining adequate CSS attribute selectors like `[colspan=n]`, though this is not trivial.\n*   To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col#attr-char) as the value of the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property Unimplemented.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -2250,7 +5304,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/col"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "tbody",
@@ -2261,7 +5329,19 @@
       "attributes": [
         {
           "name": "align",
-          "description": "This enumerated attribute specifies how horizontal alignment of each cell content will be handled. Possible values are:\n\n*   `left`, aligning the content to the left of the cell\n*   `center`, centering the content in the cell\n*   `right`, aligning the content to the right of the cell\n*   `justify`, inserting spaces into the textual content so that the content is justified in the cell\n*   `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody#attr-charoff) attributes.\n\nIf this attribute is not set, the `left` value is assumed.\n\n**Note:** Do not use this attribute as it is obsolete (not supported) in the latest standard.\n\n*   To achieve the same effect as the `left`, `center`, `right` or `justify` values, use the CSS [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property on it.\n*   To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody#attr-char) as the value of the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property Unimplemented."
+          "description": "This enumerated attribute specifies how horizontal alignment of each cell content will be handled. Possible values are:\n\n*   `left`, aligning the content to the left of the cell\n*   `center`, centering the content in the cell\n*   `right`, aligning the content to the right of the cell\n*   `justify`, inserting spaces into the textual content so that the content is justified in the cell\n*   `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody#attr-charoff) attributes.\n\nIf this attribute is not set, the `left` value is assumed.\n\n**Note:** Do not use this attribute as it is obsolete (not supported) in the latest standard.\n\n*   To achieve the same effect as the `left`, `center`, `right` or `justify` values, use the CSS [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property on it.\n*   To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody#attr-char) as the value of the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property Unimplemented.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -2269,7 +5349,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/tbody"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "thead",
@@ -2280,7 +5374,19 @@
       "attributes": [
         {
           "name": "align",
-          "description": "This enumerated attribute specifies how horizontal alignment of each cell content will be handled. Possible values are:\n\n*   `left`, aligning the content to the left of the cell\n*   `center`, centering the content in the cell\n*   `right`, aligning the content to the right of the cell\n*   `justify`, inserting spaces into the textual content so that the content is justified in the cell\n*   `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead#attr-charoff) attributes Unimplemented (see [bug 2212](https://bugzilla.mozilla.org/show_bug.cgi?id=2212 \"character alignment not implemented (align=char, charoff=, text-align:<string>)\")).\n\nIf this attribute is not set, the `left` value is assumed.\n\n**Note:** Do not use this attribute as it is obsolete (not supported) in the latest standard.\n\n*   To achieve the same effect as the `left`, `center`, `right` or `justify` values, use the CSS [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property on it.\n*   To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead#attr-char) as the value of the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property Unimplemented."
+          "description": "This enumerated attribute specifies how horizontal alignment of each cell content will be handled. Possible values are:\n\n*   `left`, aligning the content to the left of the cell\n*   `center`, centering the content in the cell\n*   `right`, aligning the content to the right of the cell\n*   `justify`, inserting spaces into the textual content so that the content is justified in the cell\n*   `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead#attr-charoff) attributes Unimplemented (see [bug 2212](https://bugzilla.mozilla.org/show_bug.cgi?id=2212 \"character alignment not implemented (align=char, charoff=, text-align:<string>)\")).\n\nIf this attribute is not set, the `left` value is assumed.\n\n**Note:** Do not use this attribute as it is obsolete (not supported) in the latest standard.\n\n*   To achieve the same effect as the `left`, `center`, `right` or `justify` values, use the CSS [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property on it.\n*   To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead#attr-char) as the value of the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property Unimplemented.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -2288,7 +5394,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/thead"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "tfoot",
@@ -2299,7 +5419,19 @@
       "attributes": [
         {
           "name": "align",
-          "description": "This enumerated attribute specifies how horizontal alignment of each cell content will be handled. Possible values are:\n\n*   `left`, aligning the content to the left of the cell\n*   `center`, centering the content in the cell\n*   `right`, aligning the content to the right of the cell\n*   `justify`, inserting spaces into the textual content so that the content is justified in the cell\n*   `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody#attr-charoff) attributes Unimplemented (see [bug 2212](https://bugzilla.mozilla.org/show_bug.cgi?id=2212 \"character alignment not implemented (align=char, charoff=, text-align:<string>)\")).\n\nIf this attribute is not set, the `left` value is assumed.\n\n**Note:** Do not use this attribute as it is obsolete (not supported) in the latest standard.\n\n*   To achieve the same effect as the `left`, `center`, `right` or `justify` values, use the CSS [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property on it.\n*   To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot#attr-char) as the value of the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property Unimplemented."
+          "description": "This enumerated attribute specifies how horizontal alignment of each cell content will be handled. Possible values are:\n\n*   `left`, aligning the content to the left of the cell\n*   `center`, centering the content in the cell\n*   `right`, aligning the content to the right of the cell\n*   `justify`, inserting spaces into the textual content so that the content is justified in the cell\n*   `char`, aligning the textual content on a special character with a minimal offset, defined by the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody#attr-charoff) attributes Unimplemented (see [bug 2212](https://bugzilla.mozilla.org/show_bug.cgi?id=2212 \"character alignment not implemented (align=char, charoff=, text-align:<string>)\")).\n\nIf this attribute is not set, the `left` value is assumed.\n\n**Note:** Do not use this attribute as it is obsolete (not supported) in the latest standard.\n\n*   To achieve the same effect as the `left`, `center`, `right` or `justify` values, use the CSS [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property on it.\n*   To achieve the same effect as the `char` value, in CSS3, you can use the value of the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot#attr-char) as the value of the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property Unimplemented.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -2307,7 +5439,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/tfoot"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "tr",
@@ -2318,7 +5464,19 @@
       "attributes": [
         {
           "name": "align",
-          "description": "A [`DOMString`](https://developer.mozilla.org/en-US/docs/Web/API/DOMString \"DOMString is a UTF-16 String. As JavaScript already uses such strings, DOMString is mapped directly to a String.\") which specifies how the cell's context should be aligned horizontally within the cells in the row; this is shorthand for using `align` on every cell in the row individually. Possible values are:\n\n`left`\n\nAlign the content of each cell at its left edge.\n\n`center`\n\nCenter the contents of each cell between their left and right edges.\n\n`right`\n\nAlign the content of each cell at its right edge.\n\n`justify`\n\nWiden whitespaces within the text of each cell so that the text fills the full width of each cell (full justification).\n\n`char`\n\nAlign each cell in the row on a specific character (such that each row in the column that is configured this way will horizontally align its cells on that character). This uses the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr#attr-charoff) to establish the alignment character (typically \".\" or \",\" when aligning numerical data) and the number of characters that should follow the alignment character. This alignment type was never widely supported.\n\nIf no value is expressly set for `align`, the parent node's value is inherited.\n\nInstead of using the obsolete `align` attribute, you should instead use the CSS [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property to establish `left`, `center`, `right`, or `justify` alignment for the row's cells. To apply character-based alignment, set the CSS [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property to the alignment character (such as `\".\"` or `\",\"`)."
+          "description": "A [`DOMString`](https://developer.mozilla.org/en-US/docs/Web/API/DOMString \"DOMString is a UTF-16 String. As JavaScript already uses such strings, DOMString is mapped directly to a String.\") which specifies how the cell's context should be aligned horizontally within the cells in the row; this is shorthand for using `align` on every cell in the row individually. Possible values are:\n\n`left`\n\nAlign the content of each cell at its left edge.\n\n`center`\n\nCenter the contents of each cell between their left and right edges.\n\n`right`\n\nAlign the content of each cell at its right edge.\n\n`justify`\n\nWiden whitespaces within the text of each cell so that the text fills the full width of each cell (full justification).\n\n`char`\n\nAlign each cell in the row on a specific character (such that each row in the column that is configured this way will horizontally align its cells on that character). This uses the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr#attr-charoff) to establish the alignment character (typically \".\" or \",\" when aligning numerical data) and the number of characters that should follow the alignment character. This alignment type was never widely supported.\n\nIf no value is expressly set for `align`, the parent node's value is inherited.\n\nInstead of using the obsolete `align` attribute, you should instead use the CSS [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property to establish `left`, `center`, `right`, or `justify` alignment for the row's cells. To apply character-based alignment, set the CSS [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property to the alignment character (such as `\".\"` or `\",\"`).",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -2326,7 +5484,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/tr"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "td",
@@ -2336,29 +5508,119 @@
       },
       "attributes": [
         {
-          "name": "colspan"
+          "name": "colspan",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "rowspan"
+          "name": "rowspan",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "headers"
+          "name": "headers",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "abbr",
-          "description": "This attribute contains a short abbreviated description of the cell's content. Some user-agents, such as speech readers, may present this description before the content itself.\n\n**Note:** Do not use this attribute as it is obsolete in the latest standard. Alternatively, you can put the abbreviated description inside the cell and place the long content in the **title** attribute."
+          "description": "This attribute contains a short abbreviated description of the cell's content. Some user-agents, such as speech readers, may present this description before the content itself.\n\n**Note:** Do not use this attribute as it is obsolete in the latest standard. Alternatively, you can put the abbreviated description inside the cell and place the long content in the **title** attribute.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "align",
-          "description": "This enumerated attribute specifies how the cell content's horizontal alignment will be handled. Possible values are:\n\n*   `left`: The content is aligned to the left of the cell.\n*   `center`: The content is centered in the cell.\n*   `right`: The content is aligned to the right of the cell.\n*   `justify` (with text only): The content is stretched out inside the cell so that it covers its entire width.\n*   `char` (with text only): The content is aligned to a character inside the `<th>` element with minimal offset. This character is defined by the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-charoff) attributes Unimplemented (see [bug 2212](https://bugzilla.mozilla.org/show_bug.cgi?id=2212 \"character alignment not implemented (align=char, charoff=, text-align:<string>)\")).\n\nThe default value when this attribute is not specified is `left`.\n\n**Note:** Do not use this attribute as it is obsolete in the latest standard.\n\n*   To achieve the same effect as the `left`, `center`, `right` or `justify` values, apply the CSS [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property to the element.\n*   To achieve the same effect as the `char` value, give the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property the same value you would use for the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-char). Unimplemented in CSS3."
+          "description": "This enumerated attribute specifies how the cell content's horizontal alignment will be handled. Possible values are:\n\n*   `left`: The content is aligned to the left of the cell.\n*   `center`: The content is centered in the cell.\n*   `right`: The content is aligned to the right of the cell.\n*   `justify` (with text only): The content is stretched out inside the cell so that it covers its entire width.\n*   `char` (with text only): The content is aligned to a character inside the `<th>` element with minimal offset. This character is defined by the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-charoff) attributes Unimplemented (see [bug 2212](https://bugzilla.mozilla.org/show_bug.cgi?id=2212 \"character alignment not implemented (align=char, charoff=, text-align:<string>)\")).\n\nThe default value when this attribute is not specified is `left`.\n\n**Note:** Do not use this attribute as it is obsolete in the latest standard.\n\n*   To achieve the same effect as the `left`, `center`, `right` or `justify` values, apply the CSS [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property to the element.\n*   To achieve the same effect as the `char` value, give the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property the same value you would use for the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-char). Unimplemented in CSS3.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "axis",
-          "description": "This attribute contains a list of space-separated strings. Each string is the `id` of a group of cells that this header applies to.\n\n**Note:** Do not use this attribute as it is obsolete in the latest standard."
+          "description": "This attribute contains a list of space-separated strings. Each string is the `id` of a group of cells that this header applies to.\n\n**Note:** Do not use this attribute as it is obsolete in the latest standard.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "bgcolor",
-          "description": "This attribute defines the background color of each cell in a column. It consists of a 6-digit hexadecimal code as defined in [sRGB](https://www.w3.org/Graphics/Color/sRGB) and is prefixed by '#'. This attribute may be used with one of sixteen predefined color strings:\n\n \n\n`black` = \"#000000\"\n\n \n\n`green` = \"#008000\"\n\n \n\n`silver` = \"#C0C0C0\"\n\n \n\n`lime` = \"#00FF00\"\n\n \n\n`gray` = \"#808080\"\n\n \n\n`olive` = \"#808000\"\n\n \n\n`white` = \"#FFFFFF\"\n\n \n\n`yellow` = \"#FFFF00\"\n\n \n\n`maroon` = \"#800000\"\n\n \n\n`navy` = \"#000080\"\n\n \n\n`red` = \"#FF0000\"\n\n \n\n`blue` = \"#0000FF\"\n\n \n\n`purple` = \"#800080\"\n\n \n\n`teal` = \"#008080\"\n\n \n\n`fuchsia` = \"#FF00FF\"\n\n \n\n`aqua` = \"#00FFFF\"\n\n**Note:** Do not use this attribute, as it is non-standard and only implemented in some versions of Microsoft Internet Explorer: The [`<td>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td \"The HTML <td> element defines a cell of a table that contains data. It participates in the table model.\") element should be styled using [CSS](https://developer.mozilla.org/en-US/docs/CSS). To create a similar effect use the [`background-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-color \"The background-color CSS property sets the background color of an element.\") property in [CSS](https://developer.mozilla.org/en-US/docs/CSS) instead."
+          "description": "This attribute defines the background color of each cell in a column. It consists of a 6-digit hexadecimal code as defined in [sRGB](https://www.w3.org/Graphics/Color/sRGB) and is prefixed by '#'. This attribute may be used with one of sixteen predefined color strings:\n\n \n\n`black` = \"#000000\"\n\n \n\n`green` = \"#008000\"\n\n \n\n`silver` = \"#C0C0C0\"\n\n \n\n`lime` = \"#00FF00\"\n\n \n\n`gray` = \"#808080\"\n\n \n\n`olive` = \"#808000\"\n\n \n\n`white` = \"#FFFFFF\"\n\n \n\n`yellow` = \"#FFFF00\"\n\n \n\n`maroon` = \"#800000\"\n\n \n\n`navy` = \"#000080\"\n\n \n\n`red` = \"#FF0000\"\n\n \n\n`blue` = \"#0000FF\"\n\n \n\n`purple` = \"#800080\"\n\n \n\n`teal` = \"#008080\"\n\n \n\n`fuchsia` = \"#FF00FF\"\n\n \n\n`aqua` = \"#00FFFF\"\n\n**Note:** Do not use this attribute, as it is non-standard and only implemented in some versions of Microsoft Internet Explorer: The [`<td>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td \"The HTML <td> element defines a cell of a table that contains data. It participates in the table model.\") element should be styled using [CSS](https://developer.mozilla.org/en-US/docs/CSS). To create a similar effect use the [`background-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-color \"The background-color CSS property sets the background color of an element.\") property in [CSS](https://developer.mozilla.org/en-US/docs/CSS) instead.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -2366,7 +5628,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/td"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "th",
@@ -2376,17 +5652,73 @@
       },
       "attributes": [
         {
-          "name": "colspan"
+          "name": "colspan",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "rowspan"
+          "name": "rowspan",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "headers"
+          "name": "headers",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "scope",
-          "valueSet": "s"
+          "valueSet": "s",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "sorted"
@@ -2396,19 +5728,69 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute contains a short abbreviated description of the cell's content. Some user-agents, such as speech readers, may present this description before the content itself."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
           "name": "align",
-          "description": "This enumerated attribute specifies how the cell content's horizontal alignment will be handled. Possible values are:\n\n*   `left`: The content is aligned to the left of the cell.\n*   `center`: The content is centered in the cell.\n*   `right`: The content is aligned to the right of the cell.\n*   `justify` (with text only): The content is stretched out inside the cell so that it covers its entire width.\n*   `char` (with text only): The content is aligned to a character inside the `<th>` element with minimal offset. This character is defined by the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-charoff) attributes.\n\nThe default value when this attribute is not specified is `left`.\n\n**Note:** Do not use this attribute as it is obsolete in the latest standard.\n\n*   To achieve the same effect as the `left`, `center`, `right` or `justify` values, apply the CSS [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property to the element.\n*   To achieve the same effect as the `char` value, give the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property the same value you would use for the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-char). Unimplemented in CSS3."
+          "description": "This enumerated attribute specifies how the cell content's horizontal alignment will be handled. Possible values are:\n\n*   `left`: The content is aligned to the left of the cell.\n*   `center`: The content is centered in the cell.\n*   `right`: The content is aligned to the right of the cell.\n*   `justify` (with text only): The content is stretched out inside the cell so that it covers its entire width.\n*   `char` (with text only): The content is aligned to a character inside the `<th>` element with minimal offset. This character is defined by the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-char) and [`charoff`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-charoff) attributes.\n\nThe default value when this attribute is not specified is `left`.\n\n**Note:** Do not use this attribute as it is obsolete in the latest standard.\n\n*   To achieve the same effect as the `left`, `center`, `right` or `justify` values, apply the CSS [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property to the element.\n*   To achieve the same effect as the `char` value, give the [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align \"The text-align CSS property sets the horizontal alignment of an inline or table-cell box. This means it works like vertical-align but in the horizontal direction.\") property the same value you would use for the [`char`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-char). Unimplemented in CSS3.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "axis",
-          "description": "This attribute contains a list of space-separated strings. Each string is the `id` of a group of cells that this header applies to.\n\n**Note:** Do not use this attribute as it is obsolete in the latest standard: use the [`scope`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-scope) attribute instead."
+          "description": "This attribute contains a list of space-separated strings. Each string is the `id` of a group of cells that this header applies to.\n\n**Note:** Do not use this attribute as it is obsolete in the latest standard: use the [`scope`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-scope) attribute instead.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": false
+          }
         },
         {
           "name": "bgcolor",
-          "description": "This attribute defines the background color of each cell in a column. It consists of a 6-digit hexadecimal code as defined in [sRGB](https://www.w3.org/Graphics/Color/sRGB) and is prefixed by '#'. This attribute may be used with one of sixteen predefined color strings:\n\n \n\n`black` = \"#000000\"\n\n \n\n`green` = \"#008000\"\n\n \n\n`silver` = \"#C0C0C0\"\n\n \n\n`lime` = \"#00FF00\"\n\n \n\n`gray` = \"#808080\"\n\n \n\n`olive` = \"#808000\"\n\n \n\n`white` = \"#FFFFFF\"\n\n \n\n`yellow` = \"#FFFF00\"\n\n \n\n`maroon` = \"#800000\"\n\n \n\n`navy` = \"#000080\"\n\n \n\n`red` = \"#FF0000\"\n\n \n\n`blue` = \"#0000FF\"\n\n \n\n`purple` = \"#800080\"\n\n \n\n`teal` = \"#008080\"\n\n \n\n`fuchsia` = \"#FF00FF\"\n\n \n\n`aqua` = \"#00FFFF\"\n\n**Note:** Do not use this attribute, as it is non-standard and only implemented in some versions of Microsoft Internet Explorer: The [`<th>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th \"The HTML <th> element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes.\") element should be styled using [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS). To create a similar effect use the [`background-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-color \"The background-color CSS property sets the background color of an element.\") property in [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) instead."
+          "description": "This attribute defines the background color of each cell in a column. It consists of a 6-digit hexadecimal code as defined in [sRGB](https://www.w3.org/Graphics/Color/sRGB) and is prefixed by '#'. This attribute may be used with one of sixteen predefined color strings:\n\n \n\n`black` = \"#000000\"\n\n \n\n`green` = \"#008000\"\n\n \n\n`silver` = \"#C0C0C0\"\n\n \n\n`lime` = \"#00FF00\"\n\n \n\n`gray` = \"#808080\"\n\n \n\n`olive` = \"#808000\"\n\n \n\n`white` = \"#FFFFFF\"\n\n \n\n`yellow` = \"#FFFF00\"\n\n \n\n`maroon` = \"#800000\"\n\n \n\n`navy` = \"#000080\"\n\n \n\n`red` = \"#FF0000\"\n\n \n\n`blue` = \"#0000FF\"\n\n \n\n`purple` = \"#800080\"\n\n \n\n`teal` = \"#008080\"\n\n \n\n`fuchsia` = \"#FF00FF\"\n\n \n\n`aqua` = \"#00FFFF\"\n\n**Note:** Do not use this attribute, as it is non-standard and only implemented in some versions of Microsoft Internet Explorer: The [`<th>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th \"The HTML <th> element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes.\") element should be styled using [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS). To create a similar effect use the [`background-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-color \"The background-color CSS property sets the background color of an element.\") property in [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) instead.",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -2416,7 +5798,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/th"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "form",
@@ -2430,6 +5826,20 @@
           "description": {
             "kind": "markdown",
             "value": "A space- or comma-delimited list of character encodings that the server accepts. The browser uses them in the order in which they are listed. The default value, the reserved string `\"UNKNOWN\"`, indicates the same encoding as that of the document containing the form element.  \nIn previous versions of HTML, the different character encodings could be delimited by spaces or commas. In HTML5, only spaces are allowed as delimiters."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2437,6 +5847,20 @@
           "description": {
             "kind": "markdown",
             "value": "The URI of a program that processes the form information. This value can be overridden by a [`formaction`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-formaction) attribute on a [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button \"The HTML <button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality.\") or [`<input>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input \"The HTML <input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent.\") element."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2445,6 +5869,20 @@
           "description": {
             "kind": "markdown",
             "value": "Indicates whether input elements can by default have their values automatically completed by the browser. This setting can be overridden by an `autocomplete` attribute on an element belonging to the form. Possible values are:\n\n*   `off`: The user must explicitly enter a value into each field for every use, or the document provides its own auto-completion method; the browser does not automatically complete entries.\n*   `on`: The browser can automatically complete values based on values that the user has previously entered in the form.\n\nFor most modern browsers (including Firefox 38+, Google Chrome 34+, IE 11+) setting the autocomplete attribute will not prevent a browser's password manager from asking the user if they want to store login fields (username and password), if the user permits the storage the browser will autofill the login the next time the user visits the page. See [The autocomplete attribute and login fields](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields).\n**Note:** If you set `autocomplete` to `off` in a form because the document provides its own auto-completion, then you should also set `autocomplete` to `off` for each of the form's `input` elements that the document can auto-complete. For details, see the note regarding Google Chrome in the [Browser Compatibility chart](#compatChart)."
+          },
+          "browsers": [
+            "C14",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2453,6 +5891,20 @@
           "description": {
             "kind": "markdown",
             "value": "When the value of the `method` attribute is `post`, enctype is the [MIME type](https://en.wikipedia.org/wiki/Mime_type) of content that is used to submit the form to the server. Possible values are:\n\n*   `application/x-www-form-urlencoded`: The default value if the attribute is not specified.\n*   `multipart/form-data`: The value used for an [`<input>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input \"The HTML <input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent.\") element with the `type` attribute set to \"file\".\n*   `text/plain`: (HTML5)\n\nThis value can be overridden by a [`formenctype`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-formenctype) attribute on a [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button \"The HTML <button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality.\") or [`<input>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input \"The HTML <input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent.\") element."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2461,6 +5913,20 @@
           "description": {
             "kind": "markdown",
             "value": "The [HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP) method that the browser uses to submit the form. Possible values are:\n\n*   `post`: Corresponds to the HTTP [POST method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5) ; form data are included in the body of the form and sent to the server.\n*   `get`: Corresponds to the HTTP [GET method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.3); form data are appended to the `action` attribute URI with a '?' as separator, and the resulting URI is sent to the server. Use this method when the form has no side-effects and contains only ASCII characters.\n*   `dialog`: Use when the form is inside a [`<dialog>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog \"The HTML <dialog> element represents a dialog box or other interactive component, such as an inspector or window.\") element to close the dialog when submitted.\n\nThis value can be overridden by a [`formmethod`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-formmethod) attribute on a [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button \"The HTML <button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality.\") or [`<input>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input \"The HTML <input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent.\") element."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2468,6 +5934,20 @@
           "description": {
             "kind": "markdown",
             "value": "The name of the form. In HTML 4, its use is deprecated (`id` should be used instead). It must be unique among the forms in a document and not just an empty string in HTML 5."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2476,6 +5956,20 @@
           "description": {
             "kind": "markdown",
             "value": "This Boolean attribute indicates that the form is not to be validated when submitted. If this attribute is not specified (and therefore the form is validated), this default setting can be overridden by a [`formnovalidate`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-formnovalidate) attribute on a [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button \"The HTML <button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality.\") or [`<input>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input \"The HTML <input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent.\") element belonging to the form."
+          },
+          "browsers": [
+            "C10",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S10.1",
+            "SM10.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2017-03-27",
+            "baseline_high_date": "2019-09-27"
           }
         },
         {
@@ -2484,6 +5978,20 @@
           "description": {
             "kind": "markdown",
             "value": "A name or keyword indicating where to display the response that is received after submitting the form. In HTML 4, this is the name/keyword for a frame. In HTML5, it is a name/keyword for a _browsing context_ (for example, tab, window, or inline frame). The following keywords have special meanings:\n\n*   `_self`: Load the response into the same HTML 4 frame (or HTML5 browsing context) as the current one. This value is the default if the attribute is not specified.\n*   `_blank`: Load the response into a new unnamed HTML 4 window or HTML5 browsing context.\n*   `_parent`: Load the response into the HTML 4 frameset parent of the current frame, or HTML5 parent browsing context of the current one. If there is no parent, this option behaves the same way as `_self`.\n*   `_top`: HTML 4: Load the response into the full original window, and cancel all other frames. HTML5: Load the response into the top-level browsing context (i.e., the browsing context that is an ancestor of the current one, and has no parent). If there is no parent, this option behaves the same way as `_self`.\n*   _iframename_: The response is displayed in a named [`<iframe>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe \"The HTML Inline Frame element (<iframe>) represents a nested browsing context, embedding another HTML page into the current one.\").\n\nHTML5: This value can be overridden by a [`formtarget`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-formtarget) attribute on a [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button \"The HTML <button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality.\") or [`<input>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input \"The HTML <input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent.\") element."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2500,7 +6008,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/form"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S3",
+        "SM2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "label",
@@ -2521,6 +6043,20 @@
           "description": {
             "kind": "markdown",
             "value": "The [`id`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-id) of a [labelable](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Form_labelable) form-related element in the same document as the `<label>` element. The first element in the document with an `id` matching the value of the `for` attribute is the _labeled control_ for this label element, if it is a labelable element. If it is not labelable then the `for` attribute has no effect. If there are other elements which also match the `id` value, later in the document, they are not considered.\n\n**Note**: A `<label>` element can have both a `for` attribute and a contained control element, as long as the `for` attribute points to the contained control element."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         }
       ],
@@ -2529,7 +6065,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/label"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "input",
@@ -2540,14 +6090,56 @@
       "void": true,
       "attributes": [
         {
-          "name": "accept"
+          "name": "accept",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "alt"
+          "name": "alt",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "autocomplete",
-          "valueSet": "inputautocomplete"
+          "valueSet": "inputautocomplete",
+          "browsers": [
+            "C14",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "autofocus",
@@ -2555,35 +6147,160 @@
         },
         {
           "name": "checked",
-          "valueSet": "v"
+          "valueSet": "v",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "dirname"
+          "name": "dirname",
+          "browsers": [
+            "C17",
+            "CA18",
+            "E79",
+            "FF116",
+            "FFA116",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "low",
+            "baseline_low_date": "2023-08-01"
+          }
         },
         {
           "name": "disabled",
-          "valueSet": "v"
+          "valueSet": "v",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "form"
+          "name": "form",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "formaction"
+          "name": "formaction",
+          "browsers": [
+            "C9",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5",
+            "SM4.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "formenctype",
-          "valueSet": "et"
+          "valueSet": "et",
+          "browsers": [
+            "C9",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5",
+            "SM4.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "formmethod",
-          "valueSet": "fm"
+          "valueSet": "fm",
+          "browsers": [
+            "C9",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5",
+            "SM4.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "formnovalidate",
-          "valueSet": "v"
+          "valueSet": "v",
+          "browsers": [
+            "C4",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5",
+            "SM4"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "formtarget"
+          "name": "formtarget",
+          "browsers": [
+            "C9",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5",
+            "SM4.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "height"
@@ -2593,49 +6310,277 @@
           "valueSet": "im"
         },
         {
-          "name": "list"
+          "name": "list",
+          "browsers": [
+            "C20",
+            "CA25",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S12.1",
+            "SM12.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2019-03-25",
+            "baseline_high_date": "2021-09-25"
+          }
         },
         {
-          "name": "max"
+          "name": "max",
+          "browsers": [
+            "C4",
+            "CA18",
+            "E12",
+            "FF16",
+            "FFA16",
+            "S5",
+            "SM4"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "maxlength"
+          "name": "maxlength",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "min"
+          "name": "min",
+          "browsers": [
+            "C4",
+            "CA18",
+            "E12",
+            "FF16",
+            "FFA16",
+            "S5",
+            "SM4"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "minlength"
+          "name": "minlength",
+          "browsers": [
+            "C40",
+            "CA40",
+            "E17",
+            "FF51",
+            "FFA51",
+            "S10.1",
+            "SM10.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2018-04-30",
+            "baseline_high_date": "2020-10-30"
+          }
         },
         {
           "name": "multiple",
-          "valueSet": "v"
+          "valueSet": "v",
+          "browsers": [
+            "C2",
+            "CA18",
+            "E12",
+            "FF3.6",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "name"
+          "name": "name",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "pattern"
+          "name": "pattern",
+          "browsers": [
+            "C4",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5",
+            "SM4"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "placeholder"
+          "name": "placeholder",
+          "browsers": [
+            "C3",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
+        },
+        {
+          "name": "popovertarget",
+          "browsers": [
+            "C114",
+            "CA114",
+            "E114",
+            "FF125",
+            "FFA125",
+            "S17",
+            "SM17"
+          ],
+          "status": {
+            "baseline": "low",
+            "baseline_low_date": "2024-04-16"
+          }
+        },
+        {
+          "name": "popovertargetaction",
+          "browsers": [
+            "C114",
+            "CA114",
+            "E114",
+            "FF125",
+            "FFA125",
+            "S17",
+            "SM17"
+          ],
+          "status": {
+            "baseline": "low",
+            "baseline_low_date": "2024-04-16"
+          }
         },
         {
           "name": "readonly",
-          "valueSet": "v"
+          "valueSet": "v",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "required",
-          "valueSet": "v"
+          "valueSet": "v",
+          "browsers": [
+            "C4",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5",
+            "SM4"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "size"
+          "name": "size",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "src"
+          "name": "src",
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S1",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
-          "name": "step"
+          "name": "step",
+          "browsers": [
+            "C5",
+            "CA18",
+            "E12",
+            "FF16",
+            "FFA16",
+            "S5",
+            "SM4"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         },
         {
           "name": "type",
@@ -2653,7 +6598,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/input"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "button",
@@ -2676,6 +6635,20 @@
           "description": {
             "kind": "markdown",
             "value": "This Boolean attribute indicates that the user cannot interact with the button. If this attribute is not specified, the button inherits its setting from the containing element, for example [`<fieldset>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset \"The HTML <fieldset> element is used to group several controls as well as labels (<label>) within a web form.\"); if there is no containing element with the **disabled** attribute set, then the button is enabled.\n\nFirefox will, unlike other browsers, by default, [persist the dynamic disabled state](https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) of a [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button \"The HTML <button> element represents a clickable button, which can be used in forms or anywhere in a document that needs simple, standard button functionality.\") across page loads. Use the [`autocomplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-autocomplete) attribute to control this feature."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2683,6 +6656,20 @@
           "description": {
             "kind": "markdown",
             "value": "The form element that the button is associated with (its _form owner_). The value of the attribute must be the **id** attribute of a [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form \"The HTML <form> element represents a document section that contains interactive controls for submitting information to a web server.\") element in the same document. If this attribute is not specified, the `<button>` element will be associated to an ancestor [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form \"The HTML <form> element represents a document section that contains interactive controls for submitting information to a web server.\") element, if one exists. This attribute enables you to associate `<button>` elements to [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form \"The HTML <form> element represents a document section that contains interactive controls for submitting information to a web server.\") elements anywhere within a document, not just as descendants of [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form \"The HTML <form> element represents a document section that contains interactive controls for submitting information to a web server.\") elements."
+          },
+          "browsers": [
+            "C9",
+            "CA18",
+            "E16",
+            "FF4",
+            "FFA4",
+            "S5.1",
+            "SM5"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2017-10-17",
+            "baseline_high_date": "2020-04-17"
           }
         },
         {
@@ -2690,6 +6677,20 @@
           "description": {
             "kind": "markdown",
             "value": "The URI of a program that processes the information submitted by the button. If specified, it overrides the [`action`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-action) attribute of the button's form owner."
+          },
+          "browsers": [
+            "C9",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5.1",
+            "SM5"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2698,6 +6699,20 @@
           "description": {
             "kind": "markdown",
             "value": "If the button is a submit button, this attribute specifies the type of content that is used to submit the form to the server. Possible values are:\n\n*   `application/x-www-form-urlencoded`: The default value if the attribute is not specified.\n*   `multipart/form-data`: Use this value if you are using an [`<input>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input \"The HTML <input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent.\") element with the [`type`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-type) attribute set to `file`.\n*   `text/plain`\n\nIf this attribute is specified, it overrides the [`enctype`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-enctype) attribute of the button's form owner."
+          },
+          "browsers": [
+            "C9",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5.1",
+            "SM5"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2706,6 +6721,20 @@
           "description": {
             "kind": "markdown",
             "value": "If the button is a submit button, this attribute specifies the HTTP method that the browser uses to submit the form. Possible values are:\n\n*   `post`: The data from the form are included in the body of the form and sent to the server.\n*   `get`: The data from the form are appended to the **form** attribute URI, with a '?' as a separator, and the resulting URI is sent to the server. Use this method when the form has no side-effects and contains only ASCII characters.\n\nIf specified, this attribute overrides the [`method`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-method) attribute of the button's form owner."
+          },
+          "browsers": [
+            "C9",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5.1",
+            "SM5"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2714,6 +6743,20 @@
           "description": {
             "kind": "markdown",
             "value": "If the button is a submit button, this Boolean attribute specifies that the form is not to be validated when it is submitted. If this attribute is specified, it overrides the [`novalidate`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-novalidate) attribute of the button's form owner."
+          },
+          "browsers": [
+            "C9",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5.1",
+            "SM5"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2721,6 +6764,20 @@
           "description": {
             "kind": "markdown",
             "value": "If the button is a submit button, this attribute is a name or keyword indicating where to display the response that is received after submitting the form. This is a name of, or keyword for, a _browsing context_ (for example, tab, window, or inline frame). If this attribute is specified, it overrides the [`target`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-target) attribute of the button's form owner. The following keywords have special meanings:\n\n*   `_self`: Load the response into the same browsing context as the current one. This value is the default if the attribute is not specified.\n*   `_blank`: Load the response into a new unnamed browsing context.\n*   `_parent`: Load the response into the parent browsing context of the current one. If there is no parent, this option behaves the same way as `_self`.\n*   `_top`: Load the response into the top-level browsing context (that is, the browsing context that is an ancestor of the current one, and has no parent). If there is no parent, this option behaves the same way as `_self`."
+          },
+          "browsers": [
+            "C9",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5.1",
+            "SM5"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2728,6 +6785,60 @@
           "description": {
             "kind": "markdown",
             "value": "The name of the button, which is submitted with the form data."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
+        },
+        {
+          "name": "popovertarget",
+          "description": {
+            "kind": "markdown",
+            "value": "Turns the button into a popover control button; takes the ID of the popover element to control as its value."
+          },
+          "browsers": [
+            "C114",
+            "CA114",
+            "E114",
+            "FF125",
+            "FFA125",
+            "S17",
+            "SM17"
+          ],
+          "status": {
+            "baseline": "low",
+            "baseline_low_date": "2024-04-16"
+          }
+        },
+        {
+          "name": "popovertargetaction",
+          "description": {
+            "kind": "markdown",
+            "value": "Specifies the action to be performed on a popover element being controlled by the button."
+          },
+          "browsers": [
+            "C114",
+            "CA114",
+            "E114",
+            "FF125",
+            "FFA125",
+            "S17",
+            "SM17"
+          ],
+          "status": {
+            "baseline": "low",
+            "baseline_low_date": "2024-04-16"
           }
         },
         {
@@ -2736,6 +6847,20 @@
           "description": {
             "kind": "markdown",
             "value": "The type of the button. Possible values are:\n\n*   `submit`: The button submits the form data to the server. This is the default if the attribute is not specified, or if the attribute is dynamically changed to an empty or invalid value.\n*   `reset`: The button resets all the controls to their initial values.\n*   `button`: The button has no default behavior. It can have client-side scripts associated with the element's events, which are triggered when the events occur."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2743,6 +6868,20 @@
           "description": {
             "kind": "markdown",
             "value": "The initial value of the button. It defines the value associated with the button which is submitted with the form data. This value is passed to the server in params when the form is submitted."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2755,7 +6894,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/button"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "select",
@@ -2770,6 +6923,20 @@
           "description": {
             "kind": "markdown",
             "value": "A [`DOMString`](https://developer.mozilla.org/en-US/docs/Web/API/DOMString \"DOMString is a UTF-16 String. As JavaScript already uses such strings, DOMString is mapped directly to a String.\") providing a hint for a [user agent's](https://developer.mozilla.org/en-US/docs/Glossary/user_agent \"user agent's: A user agent is a computer program representing a person, for example, a browser in a Web context.\") autocomplete feature. See [The HTML autocomplete attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) for a complete list of values and details on how to use autocomplete."
+          },
+          "browsers": [
+            "C66",
+            "CA66",
+            "E79",
+            "FF59",
+            "FFA59",
+            "S9.1",
+            "SM9.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2020-01-15",
+            "baseline_high_date": "2022-07-15"
           }
         },
         {
@@ -2786,6 +6953,20 @@
           "description": {
             "kind": "markdown",
             "value": "This Boolean attribute indicates that the user cannot interact with the control. If this attribute is not specified, the control inherits its setting from the containing element, for example `fieldset`; if there is no containing element with the `disabled` attribute set, then the control is enabled."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2793,6 +6974,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute lets you specify the form element to which the select element is associated (that is, its \"form owner\"). If this attribute is specified, its value must be the same as the `id` of a form element in the same document. This enables you to place select elements anywhere within a document, not just as descendants of their form elements."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2801,6 +6996,20 @@
           "description": {
             "kind": "markdown",
             "value": "This Boolean attribute indicates that multiple options can be selected in the list. If it is not specified, then only one option can be selected at a time. When `multiple` is specified, most browsers will show a scrolling list box instead of a single line dropdown."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2808,6 +7017,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute is used to specify the name of the control."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2816,6 +7039,20 @@
           "description": {
             "kind": "markdown",
             "value": "A Boolean attribute indicating that an option with a non-empty string value must be selected."
+          },
+          "browsers": [
+            "C10",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5.1",
+            "SM5"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2823,6 +7060,16 @@
           "description": {
             "kind": "markdown",
             "value": "If the control is presented as a scrolling list box (e.g. when `multiple` is specified), this attribute represents the number of rows in the list that should be visible at one time. Browsers are not required to present a select element as a scrolled list box. The default value is 0.\n\n**Note:** According to the HTML5 specification, the default value for size should be 1; however, in practice, this has been found to break some web sites, and no other browser currently does that, so Mozilla has opted to continue to return 0 for the time being with Firefox."
+          },
+          "browsers": [
+            "C1",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S3"
+          ],
+          "status": {
+            "baseline": false
           }
         }
       ],
@@ -2831,7 +7078,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/select"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "datalist",
@@ -2845,7 +7106,17 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/datalist"
         }
-      ]
+      ],
+      "browsers": [
+        "C20",
+        "CA33",
+        "E12",
+        "S12.1",
+        "SM12.2"
+      ],
+      "status": {
+        "baseline": false
+      }
     },
     {
       "name": "optgroup",
@@ -2860,6 +7131,20 @@
           "description": {
             "kind": "markdown",
             "value": "If this Boolean attribute is set, none of the items in this option group is selectable. Often browsers grey out such control and it won't receive any browsing events, like mouse clicks or focus-related ones."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2867,6 +7152,20 @@
           "description": {
             "kind": "markdown",
             "value": "The name of the group of options, which the browser can use when labeling the options in the user interface. This attribute is mandatory if this element is used."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         }
       ],
@@ -2875,7 +7174,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/optgroup"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "option",
@@ -2890,6 +7203,20 @@
           "description": {
             "kind": "markdown",
             "value": "If this Boolean attribute is set, this option is not checkable. Often browsers grey out such control and it won't receive any browsing event, like mouse clicks or focus-related ones. If this attribute is not set, the element can still be disabled if one of its ancestors is a disabled [`<optgroup>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup \"The HTML <optgroup> element creates a grouping of options within a <select> element.\") element."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2897,6 +7224,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute is text for the label indicating the meaning of the option. If the `label` attribute isn't defined, its value is that of the element text content."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2905,6 +7246,20 @@
           "description": {
             "kind": "markdown",
             "value": "If present, this Boolean attribute indicates that the option is initially selected. If the `<option>` element is the descendant of a [`<select>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select \"The HTML <select> element represents a control that provides a menu of options\") element whose [`multiple`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#attr-multiple) attribute is not set, only one single `<option>` of this [`<select>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select \"The HTML <select> element represents a control that provides a menu of options\") element may have the `selected` attribute."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2912,6 +7267,20 @@
           "description": {
             "kind": "markdown",
             "value": "The content of this attribute represents the value to be submitted with the form, should this option be selected. If this attribute is omitted, the value is taken from the text content of the option element."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         }
       ],
@@ -2920,7 +7289,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/option"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "textarea",
@@ -2935,6 +7318,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute indicates whether the value of the control can be automatically completed by the browser. Possible values are:\n\n*   `off`: The user must explicitly enter a value into this field for every use, or the document provides its own auto-completion method; the browser does not automatically complete the entry.\n*   `on`: The browser can automatically complete the value based on values that the user has entered during previous uses.\n\nIf the `autocomplete` attribute is not specified on a `<textarea>` element, then the browser uses the `autocomplete` attribute value of the `<textarea>` element's form owner. The form owner is either the [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form \"The HTML <form> element represents a document section that contains interactive controls for submitting information to a web server.\") element that this `<textarea>` element is a descendant of or the form element whose `id` is specified by the `form` attribute of the input element. For more information, see the [`autocomplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-autocomplete) attribute in [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form \"The HTML <form> element represents a document section that contains interactive controls for submitting information to a web server.\")."
+          },
+          "browsers": [
+            "C66",
+            "CA66",
+            "E79",
+            "FF59",
+            "FFA59",
+            "S9.1",
+            "SM9.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2020-01-15",
+            "baseline_high_date": "2022-07-15"
           }
         },
         {
@@ -2950,10 +7347,37 @@
           "description": {
             "kind": "markdown",
             "value": "The visible width of the text control, in average character widths. If it is specified, it must be a positive integer. If it is not specified, the default value is `20`."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
-          "name": "dirname"
+          "name": "dirname",
+          "browsers": [
+            "C17",
+            "CA18",
+            "E79",
+            "FF116",
+            "FFA116",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "low",
+            "baseline_low_date": "2023-08-01"
+          }
         },
         {
           "name": "disabled",
@@ -2961,6 +7385,20 @@
           "description": {
             "kind": "markdown",
             "value": "This Boolean attribute indicates that the user cannot interact with the control. If this attribute is not specified, the control inherits its setting from the containing element, for example [`<fieldset>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset \"The HTML <fieldset> element is used to group several controls as well as labels (<label>) within a web form.\"); if there is no containing element when the `disabled` attribute is set, the control is enabled."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2968,6 +7406,20 @@
           "description": {
             "kind": "markdown",
             "value": "The form element that the `<textarea>` element is associated with (its \"form owner\"). The value of the attribute must be the `id` of a form element in the same document. If this attribute is not specified, the `<textarea>` element must be a descendant of a form element. This attribute enables you to place `<textarea>` elements anywhere within a document, not just as descendants of form elements."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2979,6 +7431,20 @@
           "description": {
             "kind": "markdown",
             "value": "The maximum number of characters (unicode code points) that the user can enter. If this value isn't specified, the user can enter an unlimited number of characters."
+          },
+          "browsers": [
+            "C4",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5",
+            "SM4.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -2986,6 +7452,20 @@
           "description": {
             "kind": "markdown",
             "value": "The minimum number of characters (unicode code points) required that the user should enter."
+          },
+          "browsers": [
+            "C40",
+            "CA40",
+            "E17",
+            "FF51",
+            "FFA51",
+            "S10.1",
+            "SM10.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2018-04-30",
+            "baseline_high_date": "2020-10-30"
           }
         },
         {
@@ -2993,6 +7473,20 @@
           "description": {
             "kind": "markdown",
             "value": "The name of the control."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -3000,6 +7494,20 @@
           "description": {
             "kind": "markdown",
             "value": "A hint to the user of what can be entered in the control. Carriage returns or line-feeds within the placeholder text must be treated as line breaks when rendering the hint.\n\n**Note:** Placeholders should only be used to show an example of the type of data that should be entered into a form; they are _not_ a substitute for a proper [`<label>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label \"The HTML <label> element represents a caption for an item in a user interface.\") element tied to the input. See [Labels and placeholders](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Labels_and_placeholders \"The HTML <input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent.\") in [<input>: The Input (Form Input) element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input \"The HTML <input> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent.\") for a full explanation."
+          },
+          "browsers": [
+            "C4",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5",
+            "SM5"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -3008,6 +7516,20 @@
           "description": {
             "kind": "markdown",
             "value": "This Boolean attribute indicates that the user cannot modify the value of the control. Unlike the `disabled` attribute, the `readonly` attribute does not prevent the user from clicking or selecting in the control. The value of a read-only control is still submitted with the form."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -3016,6 +7538,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute specifies that the user must fill in a value before submitting a form."
+          },
+          "browsers": [
+            "C4",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S5",
+            "SM5"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -3023,6 +7559,20 @@
           "description": {
             "kind": "markdown",
             "value": "The number of visible text lines for the control."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -3031,6 +7581,20 @@
           "description": {
             "kind": "markdown",
             "value": "Indicates how the control wraps text. Possible values are:\n\n*   `hard`: The browser automatically inserts line breaks (CR+LF) so that each line has no more than the width of the control; the `cols` attribute must also be specified for this to take effect.\n*   `soft`: The browser ensures that all line breaks in the value consist of a CR+LF pair, but does not insert any additional line breaks.\n*   `off` : Like `soft` but changes appearance to `white-space: pre` so line segments exceeding `cols` are not wrapped and the `<textarea>` becomes horizontally scrollable.\n\nIf this attribute is not specified, `soft` is its default value."
+          },
+          "browsers": [
+            "C16",
+            "CA18",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -3039,7 +7603,21 @@
         },
         {
           "name": "spellcheck",
-          "description": "Specifies whether the `<textarea>` is subject to spell checking by the underlying browser/OS. the value can be:\n\n*   `true`: Indicates that the element needs to have its spelling and grammar checked.\n*   `default` : Indicates that the element is to act according to a default behavior, possibly based on the parent element's own `spellcheck` value.\n*   `false` : Indicates that the element should not be spell checked."
+          "description": "Specifies whether the `<textarea>` is subject to spell checking by the underlying browser/OS. the value can be:\n\n*   `true`: Indicates that the element needs to have its spelling and grammar checked.\n*   `default` : Indicates that the element is to act according to a default behavior, possibly based on the parent element's own `spellcheck` value.\n*   `false` : Indicates that the element should not be spell checked.",
+          "browsers": [
+            "C9",
+            "CA18",
+            "E12",
+            "FF2",
+            "FFA4",
+            "S5.1",
+            "SM5"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
+          }
         }
       ],
       "references": [
@@ -3047,7 +7625,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/textarea"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "output",
@@ -3061,6 +7653,20 @@
           "description": {
             "kind": "markdown",
             "value": "A space-separated list of other elements’ [`id`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id)s, indicating that those elements contributed input values to (or otherwise affected) the calculation."
+          },
+          "browsers": [
+            "C10",
+            "CA18",
+            "E18",
+            "FF4",
+            "FFA4",
+            "S7",
+            "SM7"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "≤2018-10-02",
+            "baseline_high_date": "≤2021-04-02"
           }
         },
         {
@@ -3068,6 +7674,20 @@
           "description": {
             "kind": "markdown",
             "value": "The [form element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) that this element is associated with (its \"form owner\"). The value of the attribute must be an `id` of a form element in the same document. If this attribute is not specified, the output element must be a descendant of a form element. This attribute enables you to place output elements anywhere within a document, not just as descendants of their form elements."
+          },
+          "browsers": [
+            "C10",
+            "CA18",
+            "E18",
+            "FF4",
+            "FFA4",
+            "S7",
+            "SM7"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "≤2018-10-02",
+            "baseline_high_date": "≤2021-04-02"
           }
         },
         {
@@ -3075,6 +7695,20 @@
           "description": {
             "kind": "markdown",
             "value": "The name of the element, exposed in the [`HTMLFormElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement \"The HTMLFormElement interface represents a <form> element in the DOM; it allows access to and in some cases modification of aspects of the form, as well as access to its component elements.\") API."
+          },
+          "browsers": [
+            "C10",
+            "CA18",
+            "E18",
+            "FF4",
+            "FFA4",
+            "S7",
+            "SM7"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "≤2018-10-02",
+            "baseline_high_date": "≤2021-04-02"
           }
         }
       ],
@@ -3083,7 +7717,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/output"
         }
-      ]
+      ],
+      "browsers": [
+        "C10",
+        "CA18",
+        "E18",
+        "FF4",
+        "FFA4",
+        "S7",
+        "SM7"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "≤2018-10-02",
+        "baseline_high_date": "≤2021-04-02"
+      }
     },
     {
       "name": "progress",
@@ -3097,6 +7745,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute specifies how much of the task that has been completed. It must be a valid floating point number between 0 and `max`, or between 0 and 1 if `max` is omitted. If there is no `value` attribute, the progress bar is indeterminate; this indicates that an activity is ongoing with no indication of how long it is expected to take."
+          },
+          "browsers": [
+            "C6",
+            "CA18",
+            "E12",
+            "FF6",
+            "FFA6",
+            "S6",
+            "SM7"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -3104,6 +7766,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute describes how much work the task indicated by the `progress` element requires. The `max` attribute, if present, must have a value greater than zero and be a valid floating point number. The default value is 1."
+          },
+          "browsers": [
+            "C6",
+            "CA18",
+            "E12",
+            "FF6",
+            "FFA6",
+            "S6",
+            "SM7"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         }
       ],
@@ -3112,7 +7788,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/progress"
         }
-      ]
+      ],
+      "browsers": [
+        "C6",
+        "CA18",
+        "E12",
+        "FF6",
+        "FFA6",
+        "S6",
+        "SM7"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "meter",
@@ -3126,6 +7816,20 @@
           "description": {
             "kind": "markdown",
             "value": "The current numeric value. This must be between the minimum and maximum values (`min` attribute and `max` attribute) if they are specified. If unspecified or malformed, the value is 0. If specified, but not within the range given by the `min` attribute and `max` attribute, the value is equal to the nearest end of the range.\n\n**Usage note:** Unless the `value` attribute is between `0` and `1` (inclusive), the `min` and `max` attributes should define the range so that the `value` attribute's value is within it."
+          },
+          "browsers": [
+            "C6",
+            "CA18",
+            "E13",
+            "FF16",
+            "FFA16",
+            "S6",
+            "SM10.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2017-03-27",
+            "baseline_high_date": "2019-09-27"
           }
         },
         {
@@ -3133,6 +7837,20 @@
           "description": {
             "kind": "markdown",
             "value": "The lower numeric bound of the measured range. This must be less than the maximum value (`max` attribute), if specified. If unspecified, the minimum value is 0."
+          },
+          "browsers": [
+            "C6",
+            "CA18",
+            "E13",
+            "FF16",
+            "FFA16",
+            "S6",
+            "SM10.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2017-03-27",
+            "baseline_high_date": "2019-09-27"
           }
         },
         {
@@ -3140,6 +7858,20 @@
           "description": {
             "kind": "markdown",
             "value": "The upper numeric bound of the measured range. This must be greater than the minimum value (`min` attribute), if specified. If unspecified, the maximum value is 1."
+          },
+          "browsers": [
+            "C6",
+            "CA18",
+            "E13",
+            "FF16",
+            "FFA16",
+            "S6",
+            "SM10.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2017-03-27",
+            "baseline_high_date": "2019-09-27"
           }
         },
         {
@@ -3147,6 +7879,20 @@
           "description": {
             "kind": "markdown",
             "value": "The upper numeric bound of the low end of the measured range. This must be greater than the minimum value (`min` attribute), and it also must be less than the high value and maximum value (`high` attribute and `max` attribute, respectively), if any are specified. If unspecified, or if less than the minimum value, the `low` value is equal to the minimum value."
+          },
+          "browsers": [
+            "C6",
+            "CA18",
+            "E13",
+            "FF16",
+            "FFA16",
+            "S6",
+            "SM10.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2017-03-27",
+            "baseline_high_date": "2019-09-27"
           }
         },
         {
@@ -3154,6 +7900,20 @@
           "description": {
             "kind": "markdown",
             "value": "The lower numeric bound of the high end of the measured range. This must be less than the maximum value (`max` attribute), and it also must be greater than the low value and minimum value (`low` attribute and **min** attribute, respectively), if any are specified. If unspecified, or if greater than the maximum value, the `high` value is equal to the maximum value."
+          },
+          "browsers": [
+            "C6",
+            "CA18",
+            "E13",
+            "FF16",
+            "FFA16",
+            "S6",
+            "SM10.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2017-03-27",
+            "baseline_high_date": "2019-09-27"
           }
         },
         {
@@ -3161,6 +7921,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute indicates the optimal numeric value. It must be within the range (as defined by the `min` attribute and `max` attribute). When used with the `low` attribute and `high` attribute, it gives an indication where along the range is considered preferable. For example, if it is between the `min` attribute and the `low` attribute, then the lower range is considered preferred."
+          },
+          "browsers": [
+            "C6",
+            "CA18",
+            "E13",
+            "FF16",
+            "FFA16",
+            "S6",
+            "SM10.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2017-03-27",
+            "baseline_high_date": "2019-09-27"
           }
         },
         {
@@ -3173,7 +7947,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/meter"
         }
-      ]
+      ],
+      "browsers": [
+        "C6",
+        "CA18",
+        "E13",
+        "FF16",
+        "FFA16",
+        "S6",
+        "SM10.3"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2017-03-27",
+        "baseline_high_date": "2019-09-27"
+      }
     },
     {
       "name": "fieldset",
@@ -3188,6 +7976,20 @@
           "description": {
             "kind": "markdown",
             "value": "If this Boolean attribute is set, all form controls that are descendants of the `<fieldset>`, are disabled, meaning they are not editable and won't be submitted along with the `<form>`. They won't receive any browsing events, like mouse clicks or focus-related events. By default browsers display such controls grayed out. Note that form elements inside the [`<legend>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend \"The HTML <legend> element represents a caption for the content of its parent <fieldset>.\") element won't be disabled."
+          },
+          "browsers": [
+            "C20",
+            "CA25",
+            "E79",
+            "FF4",
+            "FFA4",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2020-01-15",
+            "baseline_high_date": "2022-07-15"
           }
         },
         {
@@ -3195,6 +7997,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute takes the value of the `id` attribute of a [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form \"The HTML <form> element represents a document section that contains interactive controls for submitting information to a web server.\") element you want the `<fieldset>` to be part of, even if it is not inside the form."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -3202,6 +8018,20 @@
           "description": {
             "kind": "markdown",
             "value": "The name associated with the group.\n\n**Note**: The caption for the fieldset is given by the first [`<legend>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend \"The HTML <legend> element represents a caption for the content of its parent <fieldset>.\") element nested inside it."
+          },
+          "browsers": [
+            "C19",
+            "CA25",
+            "E12",
+            "FF4",
+            "FFA4",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         }
       ],
@@ -3210,7 +8040,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/fieldset"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "legend",
@@ -3224,7 +8068,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/legend"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S3",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "details",
@@ -3239,6 +8097,20 @@
           "description": {
             "kind": "markdown",
             "value": "This Boolean attribute indicates whether or not the details — that is, the contents of the `<details>` element — are currently visible. The default, `false`, means the details are not visible."
+          },
+          "browsers": [
+            "C12",
+            "CA18",
+            "E79",
+            "FF49",
+            "FFA49",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2020-01-15",
+            "baseline_high_date": "2022-07-15"
           }
         }
       ],
@@ -3247,7 +8119,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/details"
         }
-      ]
+      ],
+      "browsers": [
+        "C12",
+        "CA18",
+        "E79",
+        "FF49",
+        "FFA49",
+        "S6",
+        "SM6"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2020-01-15",
+        "baseline_high_date": "2022-07-15"
+      }
     },
     {
       "name": "summary",
@@ -3261,7 +8147,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/summary"
         }
-      ]
+      ],
+      "browsers": [
+        "C12",
+        "CA18",
+        "E79",
+        "FF49",
+        "FFA49",
+        "S6",
+        "SM6"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2020-01-15",
+        "baseline_high_date": "2022-07-15"
+      }
     },
     {
       "name": "dialog",
@@ -3272,7 +8172,21 @@
       "attributes": [
         {
           "name": "open",
-          "description": "Indicates that the dialog is active and available for interaction. When the `open` attribute is not set, the dialog shouldn't be shown to the user."
+          "description": "Indicates that the dialog is active and available for interaction. When the `open` attribute is not set, the dialog shouldn't be shown to the user.",
+          "browsers": [
+            "C37",
+            "CA37",
+            "E79",
+            "FF98",
+            "FFA98",
+            "S15.4",
+            "SM15.4"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2022-03-14",
+            "baseline_high_date": "2024-09-14"
+          }
         }
       ],
       "references": [
@@ -3280,7 +8194,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/dialog"
         }
-      ]
+      ],
+      "browsers": [
+        "C37",
+        "CA37",
+        "E79",
+        "FF98",
+        "FFA98",
+        "S15.4",
+        "SM15.4"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2022-03-14",
+        "baseline_high_date": "2024-09-14"
+      }
     },
     {
       "name": "script",
@@ -3294,6 +8222,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute specifies the URI of an external script; this can be used as an alternative to embedding a script directly within a document.\n\nIf a `script` element has a `src` attribute specified, it should not have a script embedded inside its tags."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -3301,6 +8243,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute indicates the type of script represented. The value of this attribute will be in one of the following categories:\n\n*   **Omitted or a JavaScript MIME type:** For HTML5-compliant browsers this indicates the script is JavaScript. HTML5 specification urges authors to omit the attribute rather than provide a redundant MIME type. In earlier browsers, this identified the scripting language of the embedded or imported (via the `src` attribute) code. JavaScript MIME types are [listed in the specification](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#JavaScript_types).\n*   **`module`:** For HTML5-compliant browsers the code is treated as a JavaScript module. The processing of the script contents is not affected by the `charset` and `defer` attributes. For information on using `module`, see [ES6 in Depth: Modules](https://hacks.mozilla.org/2015/08/es6-in-depth-modules/). Code may behave differently when the `module` keyword is used.\n*   **Any other value:** The embedded content is treated as a data block which won't be processed by the browser. Developers must use a valid MIME type that is not a JavaScript MIME type to denote data blocks. The `src` attribute will be ignored.\n\n**Note:** in Firefox you could specify the version of JavaScript contained in a `<script>` element by including a non-standard `version` parameter inside the `type` attribute — for example `type=\"text/javascript;version=1.8\"`. This has been removed in Firefox 59 (see [bug 1428745](https://bugzilla.mozilla.org/show_bug.cgi?id=1428745 \"FIXED: Remove support for version parameter from script loader\"))."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -3312,6 +8268,20 @@
           "description": {
             "kind": "markdown",
             "value": "This is a Boolean attribute indicating that the browser should, if possible, load the script asynchronously.\n\nThis attribute must not be used if the `src` attribute is absent (i.e. for inline scripts). If it is included in this case it will have no effect.\n\nBrowsers usually assume the worst case scenario and load scripts synchronously, (i.e. `async=\"false\"`) during HTML parsing.\n\nDynamically inserted scripts (using [`document.createElement()`](https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement \"In an HTML document, the document.createElement() method creates the HTML element specified by tagName, or an HTMLUnknownElement if tagName isn't recognized.\")) load asynchronously by default, so to turn on synchronous loading (i.e. scripts load in the order they were inserted) set `async=\"false\"`.\n\nSee [Browser compatibility](#Browser_compatibility) for notes on browser support. See also [Async scripts for asm.js](https://developer.mozilla.org/en-US/docs/Games/Techniques/Async_scripts)."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF3.6",
+            "FFA4",
+            "S4",
+            "SM3.2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -3320,6 +8290,20 @@
           "description": {
             "kind": "markdown",
             "value": "This Boolean attribute is set to indicate to a browser that the script is meant to be executed after the document has been parsed, but before firing [`DOMContentLoaded`](https://developer.mozilla.org/en-US/docs/Web/Events/DOMContentLoaded \"/en-US/docs/Web/Events/DOMContentLoaded\").\n\nScripts with the `defer` attribute will prevent the `DOMContentLoaded` event from firing until the script has loaded and finished evaluating.\n\nThis attribute must not be used if the `src` attribute is absent (i.e. for inline scripts), in this case it would have no effect.\n\nTo achieve a similar effect for dynamically inserted scripts use `async=\"false\"` instead. Scripts with the `defer` attribute will execute in the order in which they appear in the document."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF3.5",
+            "FFA4",
+            "S3",
+            "SM2"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -3328,6 +8312,20 @@
           "description": {
             "kind": "markdown",
             "value": "Normal `script` elements pass minimal information to the [`window.onerror`](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror \"The onerror property of the GlobalEventHandlers mixin is an EventHandler that processes error events.\") for scripts which do not pass the standard [CORS](https://developer.mozilla.org/en-US/docs/Glossary/CORS \"CORS: CORS (Cross-Origin Resource Sharing) is a system, consisting of transmitting HTTP headers, that determines whether browsers block frontend JavaScript code from accessing responses for cross-origin requests.\") checks. To allow error logging for sites which use a separate domain for static media, use this attribute. See [CORS settings attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for a more descriptive explanation of its valid arguments."
+          },
+          "browsers": [
+            "C19",
+            "CA25",
+            "E14",
+            "FF14",
+            "FFA14",
+            "S6",
+            "SM6"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2016-08-02",
+            "baseline_high_date": "2019-02-02"
           }
         },
         {
@@ -3339,15 +8337,57 @@
         },
         {
           "name": "integrity",
-          "description": "This attribute contains inline metadata that a user agent can use to verify that a fetched resource has been delivered free of unexpected manipulation. See [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)."
+          "description": "This attribute contains inline metadata that a user agent can use to verify that a fetched resource has been delivered free of unexpected manipulation. See [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity).",
+          "browsers": [
+            "C45",
+            "CA45",
+            "E17",
+            "FF43",
+            "FFA43",
+            "S11.1",
+            "SM11.3"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2018-04-30",
+            "baseline_high_date": "2020-10-30"
+          }
         },
         {
           "name": "nomodule",
-          "description": "This Boolean attribute is set to indicate that the script should not be executed in browsers that support [ES2015 modules](https://hacks.mozilla.org/2015/08/es6-in-depth-modules/) — in effect, this can be used to serve fallback scripts to older browsers that do not support modular JavaScript code."
+          "description": "This Boolean attribute is set to indicate that the script should not be executed in browsers that support [ES2015 modules](https://hacks.mozilla.org/2015/08/es6-in-depth-modules/) — in effect, this can be used to serve fallback scripts to older browsers that do not support modular JavaScript code.",
+          "browsers": [
+            "C61",
+            "CA61",
+            "E16",
+            "FF60",
+            "FFA60",
+            "S11",
+            "SM11"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2018-05-09",
+            "baseline_high_date": "2020-11-09"
+          }
         },
         {
           "name": "referrerpolicy",
-          "description": "Indicates which [referrer](https://developer.mozilla.org/en-US/docs/Web/API/Document/referrer) to send when fetching the script, or resources fetched by the script:\n\n*   `no-referrer`: The [`Referer`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer \"The Referer request header contains the address of the previous web page from which a link to the currently requested page was followed. The Referer header allows servers to identify where people are visiting them from and may use that data for analytics, logging, or optimized caching, for example.\") header will not be sent.\n*   `no-referrer-when-downgrade` (default): The [`Referer`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer \"The Referer request header contains the address of the previous web page from which a link to the currently requested page was followed. The Referer header allows servers to identify where people are visiting them from and may use that data for analytics, logging, or optimized caching, for example.\") header will not be sent to [origin](https://developer.mozilla.org/en-US/docs/Glossary/origin \"origin: Web content's origin is defined by the scheme (protocol), host (domain), and port of the URL used to access it. Two objects have the same origin only when the scheme, host, and port all match.\")s without [TLS](https://developer.mozilla.org/en-US/docs/Glossary/TLS \"TLS: Transport Layer Security (TLS), previously known as Secure Sockets Layer (SSL), is a protocol used by applications to communicate securely across a network, preventing tampering with and eavesdropping on email, web browsing, messaging, and other protocols.\") ([HTTPS](https://developer.mozilla.org/en-US/docs/Glossary/HTTPS \"HTTPS: HTTPS (HTTP Secure) is an encrypted version of the HTTP protocol. It usually uses SSL or TLS to encrypt all communication between a client and a server. This secure connection allows clients to safely exchange sensitive data with a server, for example for banking activities or online shopping.\")).\n*   `origin`: The sent referrer will be limited to the origin of the referring page: its [scheme](https://developer.mozilla.org/en-US/docs/Archive/Mozilla/URIScheme), [host](https://developer.mozilla.org/en-US/docs/Glossary/host \"host: A host is a device connected to the Internet (or a local network). Some hosts called servers offer additional services like serving webpages or storing files and emails.\"), and [port](https://developer.mozilla.org/en-US/docs/Glossary/port \"port: For a computer connected to a network with an IP address, a port is a communication endpoint. Ports are designated by numbers, and below 1024 each port is associated by default with a specific protocol.\").\n*   `origin-when-cross-origin`: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path.\n*   `same-origin`: A referrer will be sent for [same origin](https://developer.mozilla.org/en-US/docs/Glossary/Same-origin_policy \"same origin: The same-origin policy is a critical security mechanism that restricts how a document or script loaded from one origin can interact with a resource from another origin.\"), but cross-origin requests will contain no referrer information.\n*   `strict-origin`: Only send the origin of the document as the referrer when the protocol security level stays the same (e.g. HTTPS→HTTPS), but don't send it to a less secure destination (e.g. HTTPS→HTTP).\n*   `strict-origin-when-cross-origin`: Send a full URL when performing a same-origin request, but only send the origin when the protocol security level stays the same (e.g.HTTPS→HTTPS), and send no header to a less secure destination (e.g. HTTPS→HTTP).\n*   `unsafe-url`: The referrer will include the origin _and_ the path (but not the [fragment](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/hash), [password](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/password), or [username](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/username)). **This value is unsafe**, because it leaks origins and paths from TLS-protected resources to insecure origins.\n\n**Note**: An empty string value (`\"\"`) is both the default value, and a fallback value if `referrerpolicy` is not supported. If `referrerpolicy` is not explicitly specified on the `<script>` element, it will adopt a higher-level referrer policy, i.e. one set on the whole document or domain. If a higher-level policy is not available, the empty string is treated as being equivalent to `no-referrer-when-downgrade`."
+          "description": "Indicates which [referrer](https://developer.mozilla.org/en-US/docs/Web/API/Document/referrer) to send when fetching the script, or resources fetched by the script:\n\n*   `no-referrer`: The [`Referer`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer \"The Referer request header contains the address of the previous web page from which a link to the currently requested page was followed. The Referer header allows servers to identify where people are visiting them from and may use that data for analytics, logging, or optimized caching, for example.\") header will not be sent.\n*   `no-referrer-when-downgrade` (default): The [`Referer`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer \"The Referer request header contains the address of the previous web page from which a link to the currently requested page was followed. The Referer header allows servers to identify where people are visiting them from and may use that data for analytics, logging, or optimized caching, for example.\") header will not be sent to [origin](https://developer.mozilla.org/en-US/docs/Glossary/origin \"origin: Web content's origin is defined by the scheme (protocol), host (domain), and port of the URL used to access it. Two objects have the same origin only when the scheme, host, and port all match.\")s without [TLS](https://developer.mozilla.org/en-US/docs/Glossary/TLS \"TLS: Transport Layer Security (TLS), previously known as Secure Sockets Layer (SSL), is a protocol used by applications to communicate securely across a network, preventing tampering with and eavesdropping on email, web browsing, messaging, and other protocols.\") ([HTTPS](https://developer.mozilla.org/en-US/docs/Glossary/HTTPS \"HTTPS: HTTPS (HTTP Secure) is an encrypted version of the HTTP protocol. It usually uses SSL or TLS to encrypt all communication between a client and a server. This secure connection allows clients to safely exchange sensitive data with a server, for example for banking activities or online shopping.\")).\n*   `origin`: The sent referrer will be limited to the origin of the referring page: its [scheme](https://developer.mozilla.org/en-US/docs/Archive/Mozilla/URIScheme), [host](https://developer.mozilla.org/en-US/docs/Glossary/host \"host: A host is a device connected to the Internet (or a local network). Some hosts called servers offer additional services like serving webpages or storing files and emails.\"), and [port](https://developer.mozilla.org/en-US/docs/Glossary/port \"port: For a computer connected to a network with an IP address, a port is a communication endpoint. Ports are designated by numbers, and below 1024 each port is associated by default with a specific protocol.\").\n*   `origin-when-cross-origin`: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path.\n*   `same-origin`: A referrer will be sent for [same origin](https://developer.mozilla.org/en-US/docs/Glossary/Same-origin_policy \"same origin: The same-origin policy is a critical security mechanism that restricts how a document or script loaded from one origin can interact with a resource from another origin.\"), but cross-origin requests will contain no referrer information.\n*   `strict-origin`: Only send the origin of the document as the referrer when the protocol security level stays the same (e.g. HTTPS→HTTPS), but don't send it to a less secure destination (e.g. HTTPS→HTTP).\n*   `strict-origin-when-cross-origin`: Send a full URL when performing a same-origin request, but only send the origin when the protocol security level stays the same (e.g.HTTPS→HTTPS), and send no header to a less secure destination (e.g. HTTPS→HTTP).\n*   `unsafe-url`: The referrer will include the origin _and_ the path (but not the [fragment](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/hash), [password](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/password), or [username](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/username)). **This value is unsafe**, because it leaks origins and paths from TLS-protected resources to insecure origins.\n\n**Note**: An empty string value (`\"\"`) is both the default value, and a fallback value if `referrerpolicy` is not supported. If `referrerpolicy` is not explicitly specified on the `<script>` element, it will adopt a higher-level referrer policy, i.e. one set on the whole document or domain. If a higher-level policy is not available, the empty string is treated as being equivalent to `no-referrer-when-downgrade`.",
+          "browsers": [
+            "C70",
+            "CA70",
+            "E79",
+            "FF65",
+            "FFA65",
+            "S14",
+            "SM14"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2020-09-16",
+            "baseline_high_date": "2023-03-16"
+          }
         },
         {
           "name": "text",
@@ -3359,7 +8399,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/script"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S3",
+        "SM2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "noscript",
@@ -3373,7 +8427,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/noscript"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S3",
+        "SM2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "template",
@@ -3387,7 +8455,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/template"
         }
-      ]
+      ],
+      "browsers": [
+        "C26",
+        "CA26",
+        "E13",
+        "FF22",
+        "FFA22",
+        "S8",
+        "SM8"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-11-12",
+        "baseline_high_date": "2018-05-12"
+      }
     },
     {
       "name": "canvas",
@@ -3401,6 +8483,20 @@
           "description": {
             "kind": "markdown",
             "value": "The width of the coordinate space in CSS pixels. Defaults to 300."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1.5",
+            "FFA4",
+            "S2",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
@@ -3408,11 +8504,32 @@
           "description": {
             "kind": "markdown",
             "value": "The height of the coordinate space in CSS pixels. Defaults to 150."
+          },
+          "browsers": [
+            "C1",
+            "CA18",
+            "E12",
+            "FF1.5",
+            "FFA4",
+            "S2",
+            "SM1"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2015-07-29",
+            "baseline_high_date": "2018-01-29"
           }
         },
         {
           "name": "moz-opaque",
-          "description": "Lets the canvas know whether or not translucency will be a factor. If the canvas knows there's no translucency, painting performance can be optimized. This is only supported by Mozilla-based browsers; use the standardized [`canvas.getContext('2d', { alpha: false })`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext \"The HTMLCanvasElement.getContext() method returns a drawing context on the canvas, or null if the context identifier is not supported.\") instead."
+          "description": "Lets the canvas know whether or not translucency will be a factor. If the canvas knows there's no translucency, painting performance can be optimized. This is only supported by Mozilla-based browsers; use the standardized [`canvas.getContext('2d', { alpha: false })`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext \"The HTMLCanvasElement.getContext() method returns a drawing context on the canvas, or null if the context identifier is not supported.\") instead.",
+          "browsers": [
+            "FF3.5",
+            "FFA4"
+          ],
+          "status": {
+            "baseline": false
+          }
         }
       ],
       "references": [
@@ -3420,7 +8537,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/canvas"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1.5",
+        "FFA4",
+        "S2",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "slot",
@@ -3434,6 +8565,20 @@
           "description": {
             "kind": "markdown",
             "value": "The slot's name.\nA **named slot** is a `<slot>` element with a `name` attribute."
+          },
+          "browsers": [
+            "C53",
+            "CA53",
+            "E79",
+            "FF63",
+            "FFA63",
+            "S10",
+            "SM10"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2020-01-15",
+            "baseline_high_date": "2022-07-15"
           }
         }
       ],
@@ -3442,7 +8587,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/slot"
         }
-      ]
+      ],
+      "browsers": [
+        "C53",
+        "CA53",
+        "E79",
+        "FF63",
+        "FFA63",
+        "S10",
+        "SM10"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2020-01-15",
+        "baseline_high_date": "2022-07-15"
+      }
     },
     {
       "name": "data",
@@ -3456,6 +8615,20 @@
           "description": {
             "kind": "markdown",
             "value": "This attribute specifies the machine-readable translation of the content of the element."
+          },
+          "browsers": [
+            "C62",
+            "CA62",
+            "E14",
+            "FF22",
+            "FFA22",
+            "S10",
+            "SM10"
+          ],
+          "status": {
+            "baseline": "high",
+            "baseline_low_date": "2017-10-24",
+            "baseline_high_date": "2020-04-24"
           }
         }
       ],
@@ -3464,7 +8637,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/data"
         }
-      ]
+      ],
+      "browsers": [
+        "C62",
+        "CA62",
+        "E14",
+        "FF22",
+        "FFA22",
+        "S10",
+        "SM10"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2017-10-24",
+        "baseline_high_date": "2020-04-24"
+      }
     },
     {
       "name": "hgroup",
@@ -3478,7 +8665,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/hgroup"
         }
-      ]
+      ],
+      "browsers": [
+        "C5",
+        "CA18",
+        "E12",
+        "FF4",
+        "FFA4",
+        "S5",
+        "SM4.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "menu",
@@ -3492,7 +8693,126 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Element/menu"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S3",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
+    },
+    {
+      "name": "search",
+      "description": {
+        "kind": "markdown",
+        "value": "The search element represents the parts of the document or application with form controls or other content related to performing a search or filtering operation."
+      },
+      "attributes": [],
+      "references": [
+        {
+          "name": "MDN Reference",
+          "url": "https://developer.mozilla.org/docs/Web/HTML/Element/search"
+        }
+      ],
+      "browsers": [
+        "C118",
+        "CA118",
+        "E118",
+        "FF118",
+        "FFA118",
+        "S17",
+        "SM17"
+      ],
+      "status": {
+        "baseline": "low",
+        "baseline_low_date": "2023-10-13"
+      }
+    },
+    {
+      "name": "fencedframe",
+      "description": {
+        "kind": "markdown",
+        "value": "The fencedframe element represents a nested browsing context, embedding another HTML page into the current one."
+      },
+      "attributes": [
+        {
+          "name": "allow",
+          "browsers": [
+            "C115",
+            "CA115",
+            "E115"
+          ],
+          "status": {
+            "baseline": false
+          }
+        },
+        {
+          "name": "height",
+          "browsers": [
+            "C115",
+            "CA115",
+            "E115"
+          ],
+          "status": {
+            "baseline": false
+          }
+        },
+        {
+          "name": "width",
+          "browsers": [
+            "C115",
+            "CA115",
+            "E115"
+          ],
+          "status": {
+            "baseline": false
+          }
+        }
+      ],
+      "references": [
+        {
+          "name": "MDN Reference",
+          "url": "https://developer.mozilla.org/docs/Web/HTML/Element/fencedframe"
+        }
+      ],
+      "browsers": [
+        "C115",
+        "CA115",
+        "E115"
+      ],
+      "status": {
+        "baseline": false
+      }
+    },
+    {
+      "name": "selectedcontent",
+      "description": {
+        "kind": "markdown",
+        "value": "The selectedcontent element can be used to display the content of the currently selected option element inside of a closed select element."
+      },
+      "attributes": [],
+      "references": [
+        {
+          "name": "MDN Reference",
+          "url": "https://developer.mozilla.org/docs/Web/HTML/Element/selectedcontent"
+        }
+      ],
+      "browsers": [
+        "C134",
+        "CA134",
+        "E134"
+      ],
+      "status": {
+        "baseline": false
+      }
     }
   ],
   "globalAttributes": [
@@ -3507,7 +8827,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/accesskey"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "autocapitalize",
@@ -3520,7 +8854,65 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autocapitalize"
         }
-      ]
+      ],
+      "browsers": [
+        "C43",
+        "CA43",
+        "E79",
+        "FF111",
+        "FFA111",
+        "SM5"
+      ],
+      "status": {
+        "baseline": false
+      }
+    },
+    {
+      "name": "autocorrect",
+      "description": {
+        "kind": "markdown",
+        "value": "Controls whether autocorrection of editable text is enabled for spelling and/or punctuation errors."
+      },
+      "valueSet": "o",
+      "references": [
+        {
+          "name": "MDN Reference",
+          "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autocorrect"
+        }
+      ],
+      "browsers": [
+        "FF136",
+        "FFA136"
+      ],
+      "status": {
+        "baseline": false
+      }
+    },
+    {
+      "name": "autofocus",
+      "description": {
+        "kind": "markdown",
+        "value": "Indicates that an element should be focused on page load, or when the [`<dialog>`](https://developer.mozilla.org/docs/Web/HTML/Element/dialog) that it is part of is displayed."
+      },
+      "references": [
+        {
+          "name": "MDN Reference",
+          "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autofocus"
+        }
+      ],
+      "browsers": [
+        "C79",
+        "CA79",
+        "E79",
+        "FF110",
+        "FFA110",
+        "S15.4",
+        "SM16.4"
+      ],
+      "status": {
+        "baseline": "low",
+        "baseline_low_date": "2023-03-27"
+      }
     },
     {
       "name": "class",
@@ -3546,7 +8938,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/contenteditable"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF3",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "contextmenu",
@@ -3591,6 +8997,34 @@
       }
     },
     {
+      "name": "enterkeyhint",
+      "description": {
+        "kind": "markdown",
+        "value": "An enumerated attribute defining what action label (or icon) to present for the enter key on virtual keyboards."
+      },
+      "valueSet": "enterkeyhint",
+      "references": [
+        {
+          "name": "MDN Reference",
+          "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/enterkeyhint"
+        }
+      ],
+      "browsers": [
+        "C77",
+        "CA77",
+        "E79",
+        "FF94",
+        "FFA94",
+        "S13.1",
+        "SM13.4"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2021-11-02",
+        "baseline_high_date": "2024-05-02"
+      }
+    },
+    {
       "name": "exportparts",
       "description": {
         "kind": "markdown",
@@ -3601,7 +9035,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/exportparts"
         }
-      ]
+      ],
+      "browsers": [
+        "C73",
+        "CA73",
+        "E79",
+        "FF72",
+        "FFA79",
+        "S13.1",
+        "SM13.4"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2020-07-28",
+        "baseline_high_date": "2023-01-28"
+      }
     },
     {
       "name": "hidden",
@@ -3631,6 +9079,32 @@
       ]
     },
     {
+      "name": "inert",
+      "description": {
+        "kind": "markdown",
+        "value": "Indicates that the element and all of its flat tree descendants become _inert_. Modal `<dialog>`s generated with [`showModal()`](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/showModal) escape inertness, meaning that they don't inherit inertness from their ancestors, but can only be made inert by having the `inert` attribute explicitly set on themselves."
+      },
+      "references": [
+        {
+          "name": "MDN Reference",
+          "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inert"
+        }
+      ],
+      "browsers": [
+        "C102",
+        "CA102",
+        "E102",
+        "FF112",
+        "FFA112",
+        "S15.5",
+        "SM15.5"
+      ],
+      "status": {
+        "baseline": "low",
+        "baseline_low_date": "2023-04-11"
+      }
+    },
+    {
       "name": "inputmode",
       "description": {
         "kind": "markdown",
@@ -3641,7 +9115,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/inputmode"
         }
-      ]
+      ],
+      "browsers": [
+        "C66",
+        "CA66",
+        "E79",
+        "FF95",
+        "FFA79",
+        "S12.1",
+        "SM12.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2021-12-07",
+        "baseline_high_date": "2024-06-07"
+      }
     },
     {
       "name": "is",
@@ -3654,7 +9142,17 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/is"
         }
-      ]
+      ],
+      "browsers": [
+        "C67",
+        "CA67",
+        "E79",
+        "FF63",
+        "FFA63"
+      ],
+      "status": {
+        "baseline": false
+      }
     },
     {
       "name": "itemid",
@@ -3703,7 +9201,48 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/lang"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
+    },
+    {
+      "name": "nonce",
+      "description": {
+        "kind": "markdown",
+        "value": "Defines a cryptographic nonce (\"number used once\") which can be used by [Content Security Policy](https://developer.mozilla.org/docs/Web/HTTP/Guides/CSP) to determine whether or not a given fetch will be allowed to proceed for a given element."
+      },
+      "references": [
+        {
+          "name": "MDN Reference",
+          "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/nonce"
+        }
+      ],
+      "browsers": [
+        "C61",
+        "CA61",
+        "E79",
+        "FF31",
+        "FFA31",
+        "S15.4",
+        "SM15.4"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2022-03-14",
+        "baseline_high_date": "2024-09-14"
+      }
     },
     {
       "name": "part",
@@ -3716,7 +9255,48 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/part"
         }
-      ]
+      ],
+      "browsers": [
+        "C73",
+        "CA73",
+        "E79",
+        "FF72",
+        "FFA79",
+        "S13.1",
+        "SM13.4"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2020-07-28",
+        "baseline_high_date": "2023-01-28"
+      }
+    },
+    {
+      "name": "popover",
+      "description": {
+        "kind": "markdown",
+        "value": "Designates an element as a popover element."
+      },
+      "valueSet": "popover",
+      "references": [
+        {
+          "name": "MDN Reference",
+          "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/popover"
+        }
+      ],
+      "browsers": [
+        "C114",
+        "CA114",
+        "E114",
+        "FF125",
+        "FFA125",
+        "S17",
+        "SM17"
+      ],
+      "status": {
+        "baseline": "low",
+        "baseline_low_date": "2024-04-16"
+      }
     },
     {
       "name": "role",
@@ -3733,7 +9313,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/slot"
         }
-      ]
+      ],
+      "browsers": [
+        "C53",
+        "CA53",
+        "E79",
+        "FF63",
+        "FFA63",
+        "S10",
+        "SM10"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "≤2020-01-15",
+        "baseline_high_date": "≤2022-07-15"
+      }
     },
     {
       "name": "spellcheck",
@@ -3747,7 +9341,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/spellcheck"
         }
-      ]
+      ],
+      "browsers": [
+        "C9",
+        "CA47",
+        "E12",
+        "FF2",
+        "FFA57",
+        "S5.1",
+        "SM9.3"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2017-11-28",
+        "baseline_high_date": "2020-05-28"
+      }
     },
     {
       "name": "style",
@@ -3760,7 +9368,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/style"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S1",
+        "SM1"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "tabindex",
@@ -3773,7 +9395,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/tabindex"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1.5",
+        "FFA4",
+        "S3.1",
+        "SM2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "title",
@@ -3786,7 +9422,21 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/title"
         }
-      ]
+      ],
+      "browsers": [
+        "C1",
+        "CA18",
+        "E12",
+        "FF1",
+        "FFA4",
+        "S4",
+        "SM3.2"
+      ],
+      "status": {
+        "baseline": "high",
+        "baseline_low_date": "2015-07-29",
+        "baseline_high_date": "2018-01-29"
+      }
     },
     {
       "name": "translate",
@@ -3800,7 +9450,42 @@
           "name": "MDN Reference",
           "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/translate"
         }
-      ]
+      ],
+      "browsers": [
+        "C19",
+        "CA25",
+        "E79",
+        "FF111",
+        "FFA111",
+        "S6",
+        "SM6"
+      ],
+      "status": {
+        "baseline": "low",
+        "baseline_low_date": "2023-03-14"
+      }
+    },
+    {
+      "name": "virtualkeyboardpolicy",
+      "description": {
+        "kind": "markdown",
+        "value": "When specified on an element that the element's content is editable (for example, it is an `<input>` or `<textarea>` element, or an element with the `contenteditable` attribute set), it controls the on-screen virtual keyboard behavior on devices such as tablets, mobile phones, or other devices where a hardware keyboard may not be available."
+      },
+      "valueSet": "b",
+      "references": [
+        {
+          "name": "MDN Reference",
+          "url": "https://developer.mozilla.org/docs/Web/HTML/Global_attributes/virtualkeyboardpolicy"
+        }
+      ],
+      "browsers": [
+        "C94",
+        "CA94",
+        "E94"
+      ],
+      "status": {
+        "baseline": false
+      }
     },
     {
       "name": "onabort",
@@ -6170,6 +11855,60 @@
         },
         {
           "name": "unsafe-url"
+        }
+      ]
+    },
+    {
+      "name": "enterkeyhint",
+      "values": [
+        {
+          "name": "enter"
+        },
+        {
+          "name": "done"
+        },
+        {
+          "name": "go"
+        },
+        {
+          "name": "next"
+        },
+        {
+          "name": "previous"
+        },
+        {
+          "name": "search"
+        },
+        {
+          "name": "send"
+        }
+      ]
+    },
+    {
+      "name": "popover",
+      "values": [
+        {
+          "name": "auto"
+        },
+        {
+          "name": "hint"
+        },
+        {
+          "name": "manual"
+        }
+      ]
+    },
+    {
+      "name": "fetchpriority",
+      "values": [
+        {
+          "name": "high"
+        },
+        {
+          "name": "low"
+        },
+        {
+          "name": "auto"
         }
       ]
     }

--- a/web-data/html/htmlGlobalAttributes.json
+++ b/web-data/html/htmlGlobalAttributes.json
@@ -8,6 +8,15 @@
     "description": "Controls whether and how text input is automatically capitalized as it is entered/edited by the user. It can have the following values:\n\n*   `off` or `none`, no autocapitalization is applied (all letters default to lowercase)\n*   `on` or `sentences`, the first letter of each sentence defaults to a capital letter; all other letters default to lowercase\n*   `words`, the first letter of each word defaults to a capital letter; all other letters default to lowercase\n*   `characters`, all letters should default to uppercase"
   },
   {
+    "name": "autocorrect",
+    "description": "Controls whether autocorrection of editable text is enabled for spelling and/or punctuation errors.",
+    "valueSet": "o"
+  },
+  {
+    "name": "autofocus",
+    "description": "Indicates that an element should be focused on page load, or when the [`<dialog>`](https://developer.mozilla.org/docs/Web/HTML/Element/dialog) that it is part of is displayed."
+  },
+  {
     "name": "class",
     "description": "A space-separated list of the classes of the element. Classes allows CSS and JavaScript to select and access specific elements via the [class selectors](https://developer.mozilla.org/docs/Web/CSS/Class_selectors) or functions like the method [`Document.getElementsByClassName()`](https://developer.mozilla.org/docs/Web/API/Document/getElementsByClassName \"returns an array-like object of all child elements which have all of the given class names.\")."
   },
@@ -34,6 +43,11 @@
     "description": "An enumerated attribute indicating what types of content can be dropped on an element, using the [Drag and Drop API](https://developer.mozilla.org/docs/DragDrop/Drag_and_Drop). It can have the following values:\n\n*   `copy`, which indicates that dropping will create a copy of the element that was dragged\n*   `move`, which indicates that the element that was dragged will be moved to this new location.\n*   `link`, will create a link to the dragged data."
   },
   {
+    "name": "enterkeyhint",
+    "description": "An enumerated attribute defining what action label (or icon) to present for the enter key on virtual keyboards.",
+    "valueSet": "enterkeyhint"
+  },
+  {
     "name": "exportparts",
     "description": "Used to transitively export shadow parts from a nested shadow tree into a containing light tree."
   },
@@ -45,6 +59,10 @@
   {
     "name": "id",
     "description": "Defines a unique identifier (ID) which must be unique in the whole document. Its purpose is to identify the element when linking (using a fragment identifier), scripting, or styling (with CSS)."
+  },
+  {
+    "name": "inert",
+    "description": "Indicates that the element and all of its flat tree descendants become _inert_. Modal `<dialog>`s generated with [`showModal()`](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/showModal) escape inertness, meaning that they don't inherit inertness from their ancestors, but can only be made inert by having the `inert` attribute explicitly set on themselves."
   },
   {
     "name": "inputmode",
@@ -80,8 +98,17 @@
     "description": "Helps define the language of an element: the language that non-editable elements are in, or the language that editable elements should be written in by the user. The attribute contains one “language tag” (made of hyphen-separated “language subtags”) in the format defined in [_Tags for Identifying Languages (BCP47)_](https://www.ietf.org/rfc/bcp/bcp47.txt). [**xml:lang**](#attr-xml:lang) has priority over it."
   },
   {
+    "name": "nonce",
+    "description": "Defines a cryptographic nonce (\"number used once\") which can be used by [Content Security Policy](https://developer.mozilla.org/docs/Web/HTTP/Guides/CSP) to determine whether or not a given fetch will be allowed to proceed for a given element."
+  },
+  {
     "name": "part",
     "description": "A space-separated list of the part names of the element. Part names allows CSS to select and style specific elements in a shadow tree via the [`::part`](https://developer.mozilla.org/docs/Web/CSS/::part \"The ::part CSS pseudo-element represents any element within a shadow tree that has a matching part attribute.\") pseudo-element."
+  },
+  {
+    "name": "popover",
+    "description": "Designates an element as a popover element.",
+    "valueSet": "popover"
   },
   {
     "name": "role",
@@ -112,5 +139,10 @@
     "name": "translate",
     "description": "An enumerated attribute that is used to specify whether an element's attribute values and the values of its [`Text`](https://developer.mozilla.org/docs/Web/API/Text \"The Text interface represents the textual content of Element or Attr. If an element has no markup within its content, it has a single child implementing Text that contains the element's text. However, if the element contains markup, it is parsed into information items and Text nodes that form its children.\") node children are to be translated when the page is localized, or whether to leave them unchanged. It can have the following values:\n\n*   empty string and `yes`, which indicates that the element will be translated.\n*   `no`, which indicates that the element will not be translated.",
     "valueSet": "y"
+  },
+  {
+    "name": "virtualkeyboardpolicy",
+    "description": "When specified on an element that the element's content is editable (for example, it is an `<input>` or `<textarea>` element, or an element with the `contenteditable` attribute set), it controls the on-screen virtual keyboard behavior on devices such as tablets, mobile phones, or other devices where a hardware keyboard may not be available.",
+    "valueSet": "b"
   }
 ]

--- a/web-data/html/htmlTags.json
+++ b/web-data/html/htmlTags.json
@@ -544,6 +544,10 @@
         }
       },
       {
+        "name": "fetchpriority",
+        "valueSet": "fetchpriority"
+      },
+      {
         "name": "referrerpolicy",
         "valueSet": "referrerpolicy"
       },
@@ -1041,6 +1045,12 @@
         "name": "placeholder"
       },
       {
+        "name": "popovertarget"
+      },
+      {
+        "name": "popovertargetaction"
+      },
+      {
         "name": "readonly",
         "valueSet": "v"
       },
@@ -1104,6 +1114,12 @@
       },
       {
         "name": "name"
+      },
+      {
+        "name": "popovertarget"
+      },
+      {
+        "name": "popovertargetaction"
       },
       {
         "name": "type",
@@ -1415,6 +1431,31 @@
   {
     "name": "menu",
     "description": "The menu element represents an unordered list of interactive items.",
+    "attributes": []
+  },
+  {
+    "name": "search",
+    "description": "The search element represents the parts of the document or application with form controls or other content related to performing a search or filtering operation.",
+    "attributes": []
+  },
+  {
+    "name": "fencedframe",
+    "description": "The fencedframe element represents a nested browsing context, embedding another HTML page into the current one.",
+    "attributes": [
+      {
+        "name": "allow"
+      },
+      {
+        "name": "height"
+      },
+      {
+        "name": "width"
+      }
+    ]
+  },
+  {
+    "name": "selectedcontent",
+    "description": "The selectedcontent element can be used to display the content of the currently selected option element inside of a closed select element.",
     "attributes": []
   }
 ]

--- a/web-data/html/mdnTagDescriptions.json
+++ b/web-data/html/mdnTagDescriptions.json
@@ -316,6 +316,14 @@
         "description": "The name of the button, which is submitted with the form data."
       },
       {
+        "name": "popovertarget",
+        "description": "Turns the button into a popover control button; takes the ID of the popover element to control as its value."
+      },
+      {
+        "name": "popovertargetaction",
+        "description": "Specifies the action to be performed on a popover element being controlled by the button."
+      },
+      {
         "name": "type",
         "description": "The type of the button. Possible values are:\n\n*   `submit`: The button submits the form data to the server. This is the default if the attribute is not specified, or if the attribute is dynamically changed to an empty or invalid value.\n*   `reset`: The button resets all the controls to their initial values.\n*   `button`: The button has no default behavior. It can have client-side scripts associated with the element's events, which are triggered when the events occur."
       },
@@ -733,6 +741,10 @@
       {
         "name": "decoding",
         "description": "`sync`\n\nDecode the image synchronously for atomic presentation with other content.\n\n`async`\n\nDecode the image asynchronously to reduce delay in presenting other content.\n\n`auto`\n\nDefault mode, which indicates no preference for the decoding mode. The browser decides what is best for the user."
+      },
+      {
+        "name": "fetchpriority",
+        "description": "Provides a hint of the relative priority to use when fetching the image."
       },
       {
         "name": "height",

--- a/web-data/html/valueSets.json
+++ b/web-data/html/valueSets.json
@@ -1268,5 +1268,59 @@
         "name": "unsafe-url"
       }
     ]
+  },
+  {
+    "name": "enterkeyhint",
+    "values": [
+      {
+        "name": "enter"
+      },
+      {
+        "name": "done"
+      },
+      {
+        "name": "go"
+      },
+      {
+        "name": "next"
+      },
+      {
+        "name": "previous"
+      },
+      {
+        "name": "search"
+      },
+      {
+        "name": "send"
+      }
+    ]
+  },
+  {
+    "name": "popover",
+    "values": [
+      {
+        "name": "auto"
+      },
+      {
+        "name": "hint"
+      },
+      {
+        "name": "manual"
+      }
+    ]
+  },
+  {
+    "name": "fetchpriority",
+    "values": [
+      {
+        "name": "high"
+      },
+      {
+        "name": "low"
+      },
+      {
+        "name": "auto"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Progress on https://github.com/microsoft/vscode-css-languageservice/issues/427

Similar to #111, this adds baseline info to the generated HTML data to be shown in element and attribute hovercards

All changes:

- adds new `baseline` and `browsers` objects to all supported HTML elements, element-specific attributes, and global attributes, in the same format as the one used by the CSS data
- adds all missing (non-deprecated) elements
  - search
  - fencedframe
  - selectedcontent
- adds a few missing element-specific attributes
  - img[fetchpriority]
  - input[popovertarget]
  - input[popovertargetaction]
  - button[popovertarget]
  - button[popovertargetaction]
- adds all missing global attributes
  - autocorrect
  - autofocus
  - enterkeyhint
  - inert
  - nonce
  - popover
  - virtualkeyboardpolicy
  - I intentionally did NOT add [anchor](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/anchor), which is non-standard
- adds descriptions and valueSets for elements and attributes as needed

The missing elements and attributes were kind of important to add because they tend to be newer features, and developers would benefit from having clearer browser support info for those in particular.