### PR TITLE
Restore media query value data after webref/css update

### DIFF
--- a/web-data/css/add-atrule-descriptors.mjs
+++ b/web-data/css/add-atrule-descriptors.mjs
@@ -1,4 +1,5 @@
 import { listAll } from '@webref/css'
+import { definitionSyntax } from 'css-tree'
 
 export async function addAtRuleDescriptors(atDirectives) {
     await addMediaQueryAtRuleDescriptors(atDirectives.find((directive) => directive.name === '@media'))
@@ -24,12 +25,11 @@ async function addMediaQueryAtRuleDescriptors(atDirective) {
             name: descriptor.name,
             references: [{ name: 'W3C Reference', url: descriptor.href }],
             type: descriptor.type,
-            syntax: descriptor.value,
-            values: descriptor.values?.map((value) => ({
-                name: value.name,
-                description: value.prose,
-                references: [{ name: 'W3C Reference', url: value.href }],
-            })),
+            syntax: descriptor.syntax,
+            values: !descriptor.syntax.startsWith("<")
+                ? definitionSyntax.parse(descriptor.syntax).terms
+                    .map((value) => ({ name: value.name }))
+                : undefined,
         })
     }
     atDirective.descriptors = outDescriptors

--- a/web-data/data/browsers.css-data.json
+++ b/web-data/data/browsers.css-data.json
@@ -28559,6 +28559,7 @@
             }
           ],
           "type": "range",
+          "syntax": "<number>",
           "description": "The -webkit-device-pixel-ratio is a non-standard Boolean CSS media feature which is an alternative to the standard resolution media feature.",
           "browsers": [
             "E12",
@@ -28589,6 +28590,7 @@
             }
           ],
           "type": "discrete",
+          "syntax": "<mq-boolean>",
           "description": "The -webkit-transform-3d Boolean CSS media feature is a WebKit extension whose value is true if vendor-prefixed CSS 3D transforms are supported.",
           "browsers": [
             "E12",
@@ -28619,6 +28621,15 @@
             }
           ],
           "type": "discrete",
+          "syntax": "none | hover",
+          "values": [
+            {
+              "name": "none"
+            },
+            {
+              "name": "hover"
+            }
+          ],
           "description": "The any-hover CSS media feature can be used to test whether any available input mechanism can hover over elements.",
           "browsers": [
             "E16",
@@ -28649,6 +28660,18 @@
             }
           ],
           "type": "discrete",
+          "syntax": "none | coarse | fine",
+          "values": [
+            {
+              "name": "none"
+            },
+            {
+              "name": "coarse"
+            },
+            {
+              "name": "fine"
+            }
+          ],
           "description": "The any-pointer CSS media feature tests whether the user has any pointing device (such as a mouse), and if so, how accurate it is.",
           "browsers": [
             "E12",
@@ -28679,6 +28702,7 @@
             }
           ],
           "type": "range",
+          "syntax": "<ratio>",
           "description": "The aspect-ratio CSS media feature can be used to test the aspect ratio of the viewport.",
           "browsers": [
             "E12",
@@ -28710,6 +28734,7 @@
             }
           ],
           "type": "range",
+          "syntax": "<integer>",
           "description": "The color CSS media feature can be used to test the number of bits per color component (red, green, blue) of the output device.",
           "browsers": [
             "E12",
@@ -28741,6 +28766,18 @@
             }
           ],
           "type": "discrete",
+          "syntax": "srgb | p3 | rec2020",
+          "values": [
+            {
+              "name": "srgb"
+            },
+            {
+              "name": "p3"
+            },
+            {
+              "name": "rec2020"
+            }
+          ],
           "description": "The color-gamut CSS media feature is used to apply CSS styles based on the approximate range of color gamut supported by the user agent and the output device.",
           "browsers": [
             "E79",
@@ -28771,6 +28808,7 @@
             }
           ],
           "type": "range",
+          "syntax": "<integer>",
           "description": "The color-index CSS media feature can be used to test the number of entries in the output device's color lookup table.",
           "browsers": [
             "E79",
@@ -28797,6 +28835,7 @@
             }
           ],
           "type": "range",
+          "syntax": "<ratio>",
           "description": "The device-aspect-ratio CSS media feature can be used to test the width-to-height aspect ratio of an output device.",
           "status": "obsolete",
           "browsers": [
@@ -28827,6 +28866,7 @@
             }
           ],
           "type": "range",
+          "syntax": "<length>",
           "description": "The device-height CSS media feature can be used to test the height of an output device's rendering surface.",
           "status": "obsolete",
           "browsers": [
@@ -28857,6 +28897,7 @@
             }
           ],
           "type": "range",
+          "syntax": "<length>",
           "description": "The device-width CSS media feature can be used to test the width of an output device's rendering surface.",
           "status": "obsolete",
           "browsers": [
@@ -28887,6 +28928,24 @@
             }
           ],
           "type": "discrete",
+          "syntax": "fullscreen | standalone | minimal-ui | browser | picture-in-picture",
+          "values": [
+            {
+              "name": "fullscreen"
+            },
+            {
+              "name": "standalone"
+            },
+            {
+              "name": "minimal-ui"
+            },
+            {
+              "name": "browser"
+            },
+            {
+              "name": "picture-in-picture"
+            }
+          ],
           "description": "The display-mode CSS media feature can be used to test whether a web app is being displayed in a normal browser tab or in some alternative way, such as a standalone app or fullscreen mode.",
           "browsers": [
             "E79",
@@ -28914,6 +28973,15 @@
             }
           ],
           "type": "discrete",
+          "syntax": "standard | high",
+          "values": [
+            {
+              "name": "standard"
+            },
+            {
+              "name": "high"
+            }
+          ],
           "description": "The dynamic-range CSS media feature can be used to test the combination of brightness, contrast ratio, and color depth that are supported by the user agent and the output device.",
           "browsers": [
             "E98",
@@ -28939,7 +29007,19 @@
               "url": "https://drafts.csswg.org/mediaqueries-5/#descdef-media-environment-blending"
             }
           ],
-          "type": "discrete"
+          "type": "discrete",
+          "syntax": "opaque | additive | subtractive",
+          "values": [
+            {
+              "name": "opaque"
+            },
+            {
+              "name": "additive"
+            },
+            {
+              "name": "subtractive"
+            }
+          ]
         },
         {
           "name": "forced-colors",
@@ -28954,6 +29034,15 @@
             }
           ],
           "type": "discrete",
+          "syntax": "none | active",
+          "values": [
+            {
+              "name": "none"
+            },
+            {
+              "name": "active"
+            }
+          ],
           "description": "The forced-colors CSS media feature is used to detect if the user agent has enabled a forced colors mode where it enforces a user-chosen limited color palette on the page. An example of a forced colors mode is Windows High Contrast mode.",
           "browsers": [
             "E79",
@@ -28984,6 +29073,7 @@
             }
           ],
           "type": "discrete",
+          "syntax": "<mq-boolean>",
           "description": "The grid CSS media feature can be used to test whether the output device uses a grid-based screen.",
           "browsers": [
             "E12",
@@ -29015,6 +29105,7 @@
             }
           ],
           "type": "range",
+          "syntax": "<length>",
           "description": "The height CSS media feature can be used to apply styles based on the height of the viewport (or the page box, for paged media).",
           "browsers": [
             "E12",
@@ -29046,6 +29137,7 @@
             }
           ],
           "type": "range",
+          "syntax": "<integer>",
           "browsers": [
             "E138",
             "C138",
@@ -29069,6 +29161,15 @@
             }
           ],
           "type": "discrete",
+          "syntax": "none | hover",
+          "values": [
+            {
+              "name": "none"
+            },
+            {
+              "name": "hover"
+            }
+          ],
           "description": "The hover CSS media feature can be used to test whether the user's primary input mechanism can hover over elements.",
           "browsers": [
             "E12",
@@ -29099,6 +29200,15 @@
             }
           ],
           "type": "discrete",
+          "syntax": "none | inverted",
+          "values": [
+            {
+              "name": "none"
+            },
+            {
+              "name": "inverted"
+            }
+          ],
           "description": "The inverted-colors CSS media feature is used to test if the user agent or the underlying operating system has inverted all colors.",
           "browsers": [
             "S9.1",
@@ -29121,6 +29231,7 @@
             }
           ],
           "type": "range",
+          "syntax": "<integer>",
           "description": "The monochrome CSS media feature can be used to test the number of bits per pixel in the monochrome frame buffer of the output device.",
           "browsers": [
             "E79",
@@ -29146,7 +29257,16 @@
               "url": "https://drafts.csswg.org/mediaqueries-5/#descdef-media-nav-controls"
             }
           ],
-          "type": "discrete"
+          "type": "discrete",
+          "syntax": "none | back",
+          "values": [
+            {
+              "name": "none"
+            },
+            {
+              "name": "back"
+            }
+          ]
         },
         {
           "name": "orientation",
@@ -29161,6 +29281,15 @@
             }
           ],
           "type": "discrete",
+          "syntax": "portrait | landscape",
+          "values": [
+            {
+              "name": "portrait"
+            },
+            {
+              "name": "landscape"
+            }
+          ],
           "description": "The orientation CSS media feature can be used to test the orientation of the viewport (or the page box, for paged media).",
           "browsers": [
             "E12",
@@ -29192,6 +29321,18 @@
             }
           ],
           "type": "discrete",
+          "syntax": "none | scroll | paged",
+          "values": [
+            {
+              "name": "none"
+            },
+            {
+              "name": "scroll"
+            },
+            {
+              "name": "paged"
+            }
+          ],
           "description": "The overflow-block CSS media feature can be used to test how the output device handles content that overflows the initial containing block along the block axis.",
           "browsers": [
             "E113",
@@ -29221,6 +29362,15 @@
             }
           ],
           "type": "discrete",
+          "syntax": "none | scroll",
+          "values": [
+            {
+              "name": "none"
+            },
+            {
+              "name": "scroll"
+            }
+          ],
           "description": "The overflow-inline CSS media feature can be used to test how the output device handles content that overflows the initial containing block along the inline axis.",
           "browsers": [
             "E113",
@@ -29250,6 +29400,18 @@
             }
           ],
           "type": "discrete",
+          "syntax": "none | coarse | fine",
+          "values": [
+            {
+              "name": "none"
+            },
+            {
+              "name": "coarse"
+            },
+            {
+              "name": "fine"
+            }
+          ],
           "description": "The pointer CSS media feature tests whether the user has a pointing device (such as a mouse), and if so, how accurate the primary pointing device is.",
           "browsers": [
             "E12",
@@ -29280,6 +29442,15 @@
             }
           ],
           "type": "discrete",
+          "syntax": "light | dark",
+          "values": [
+            {
+              "name": "light"
+            },
+            {
+              "name": "dark"
+            }
+          ],
           "description": "The prefers-color-scheme CSS media feature is used to detect if a user has requested light or dark color themes.",
           "browsers": [
             "E79",
@@ -29310,6 +29481,21 @@
             }
           ],
           "type": "discrete",
+          "syntax": "no-preference | less | more | custom",
+          "values": [
+            {
+              "name": "no-preference"
+            },
+            {
+              "name": "less"
+            },
+            {
+              "name": "more"
+            },
+            {
+              "name": "custom"
+            }
+          ],
           "description": "The prefers-contrast CSS media feature is used to detect whether the user has requested the web content to be presented with a lower or higher contrast.",
           "browsers": [
             "E96",
@@ -29340,6 +29526,15 @@
             }
           ],
           "type": "discrete",
+          "syntax": "no-preference | reduce",
+          "values": [
+            {
+              "name": "no-preference"
+            },
+            {
+              "name": "reduce"
+            }
+          ],
           "description": "The prefers-reduced-data CSS media feature is used to detect if the user has requested the web content that consumes less internet traffic.",
           "status": "experimental",
           "browsers": [
@@ -29362,6 +29557,15 @@
             }
           ],
           "type": "discrete",
+          "syntax": "no-preference | reduce",
+          "values": [
+            {
+              "name": "no-preference"
+            },
+            {
+              "name": "reduce"
+            }
+          ],
           "description": "The prefers-reduced-motion CSS media feature is used to detect if a user has enabled a setting on their device to minimize the amount of non-essential motion. The setting is used to convey to the browser on the device that the user prefers an interface that removes, reduces, or replaces motion-based animations.",
           "browsers": [
             "E79",
@@ -29392,6 +29596,15 @@
             }
           ],
           "type": "discrete",
+          "syntax": "no-preference | reduce",
+          "values": [
+            {
+              "name": "no-preference"
+            },
+            {
+              "name": "reduce"
+            }
+          ],
           "description": "The prefers-reduced-transparency CSS media feature is used to detect if a user has enabled a setting on their device to reduce the transparent or translucent layer effects used on the device. Switching on such a setting can help improve contrast and readability for some users.",
           "status": "experimental",
           "browsers": [
@@ -29417,6 +29630,7 @@
             }
           ],
           "type": "range",
+          "syntax": "<resolution> | infinite",
           "description": "The resolution CSS media feature can be used to test the pixel density of the output device.",
           "browsers": [
             "E12",
@@ -29444,6 +29658,15 @@
             }
           ],
           "type": "discrete",
+          "syntax": "interlace | progressive",
+          "values": [
+            {
+              "name": "interlace"
+            },
+            {
+              "name": "progressive"
+            }
+          ],
           "description": "The scan CSS media feature is used to apply CSS styles based on the scanning process of the output device."
         },
         {
@@ -29459,6 +29682,18 @@
             }
           ],
           "type": "discrete",
+          "syntax": "none | initial-only | enabled",
+          "values": [
+            {
+              "name": "none"
+            },
+            {
+              "name": "initial-only"
+            },
+            {
+              "name": "enabled"
+            }
+          ],
           "description": "The scripting CSS media feature can be used to test whether scripting (such as JavaScript) is available.",
           "browsers": [
             "E120",
@@ -29484,6 +29719,15 @@
             }
           ],
           "type": "discrete",
+          "syntax": "rect | round",
+          "values": [
+            {
+              "name": "rect"
+            },
+            {
+              "name": "round"
+            }
+          ],
           "description": "The shape CSS media feature can be used to test the shape of the device to distinguish rectangular and round displays."
         },
         {
@@ -29499,6 +29743,18 @@
             }
           ],
           "type": "discrete",
+          "syntax": "none | slow | fast",
+          "values": [
+            {
+              "name": "none"
+            },
+            {
+              "name": "slow"
+            },
+            {
+              "name": "fast"
+            }
+          ],
           "description": "The update CSS media feature can be used to test how frequently (if at all) the output device is able to modify the appearance of content once rendered.",
           "browsers": [
             "E113",
@@ -29528,6 +29784,7 @@
             }
           ],
           "type": "range",
+          "syntax": "<integer>",
           "browsers": [
             "E138",
             "C138",
@@ -29546,7 +29803,19 @@
               "url": "https://drafts.csswg.org/mediaqueries-5/#descdef-media-video-color-gamut"
             }
           ],
-          "type": "discrete"
+          "type": "discrete",
+          "syntax": "srgb | p3 | rec2020",
+          "values": [
+            {
+              "name": "srgb"
+            },
+            {
+              "name": "p3"
+            },
+            {
+              "name": "rec2020"
+            }
+          ]
         },
         {
           "name": "video-dynamic-range",
@@ -29561,6 +29830,15 @@
             }
           ],
           "type": "discrete",
+          "syntax": "standard | high",
+          "values": [
+            {
+              "name": "standard"
+            },
+            {
+              "name": "high"
+            }
+          ],
           "description": "The video-dynamic-range CSS media feature can be used to test the combination of brightness, contrast ratio, and color depth that are supported by the video plane of the user agent and the output device.",
           "browsers": [
             "FF100",
@@ -29584,6 +29862,7 @@
             }
           ],
           "type": "range",
+          "syntax": "<length>",
           "description": "The width CSS media feature can be used to test the width of the viewport (or the page box, for paged media).",
           "browsers": [
             "E12",

--- a/web-data/package-lock.json
+++ b/web-data/package-lock.json
@@ -12,6 +12,7 @@
         "@mdn/browser-compat-data": "^7.1.8",
         "@webref/css": "^7.1.0",
         "compute-baseline": "^0.4.0",
+        "css-tree": "^3.1.0",
         "mdn-data": "^2.24.0"
       }
     },
@@ -72,7 +73,6 @@
       "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.12.2",
         "source-map-js": "^1.0.1"
@@ -86,8 +86,7 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "dev": true,
-      "license": "CC0-1.0",
-      "peer": true
+      "license": "CC0-1.0"
     },
     "node_modules/jsbi": {
       "version": "4.3.2",
@@ -109,7 +108,6 @@
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/web-data/package.json
+++ b/web-data/package.json
@@ -21,6 +21,7 @@
     "@mdn/browser-compat-data": "^7.1.8",
     "@webref/css": "^7.1.0",
     "compute-baseline": "^0.4.0",
+    "css-tree": "^3.1.0",
     "mdn-data": "^2.24.0"
   }
 }


### PR DESCRIPTION
We lost the possible values in media queries in #128 which are used for completions in `vscode-css-languageservice`.

The changelog recommends parsing the syntax field with [css-tree](https://www.npmjs.com/package/css-tree). 

> Feature syntaxes were stored in a value key. That key is now named syntax. Actual syntax values are the same as before and can be parsed with CSSTree.


> Some of the possible values that a CSS feature could take appeared nested under that feature definition in a values key in version 6. Such values are no longer reported in the new version [...] [Y]ou will need to parse the feature's syntax (the syntax key) to extract keyword values.
>

There is no replacement to the prose and reference href as far as I can tell.