### PR TITLE
join split importance attribute of img tag

### DIFF
--- a/web-data/data/browsers.html-data.json
+++ b/web-data/data/browsers.html-data.json
@@ -3471,11 +3471,7 @@
         },
         {
           "name": "importance",
-          "description": "Indicates the relative importance of the resource. Priority hints are delegated using the values:"
-        },
-        {
-          "name": "importance",
-          "description": "`auto`: Indicates **no preference**. The browser may use its own heuristics to decide the priority of the image.\n\n`high`: Indicates to the browser that the image is of **high** priority.\n\n`low`: Indicates to the browser that the image is of **low** priority."
+          "description": "Indicates the relative importance of the resource. Priority hints are delegated using the values:\n\n`auto`: Indicates **no preference**. The browser may use its own heuristics to decide the priority of the image.\n\n`high`: Indicates to the browser that the image is of **high** priority.\n\n`low`: Indicates to the browser that the image is of **low** priority."
         },
         {
           "name": "intrinsicsize",

--- a/web-data/html/mdnTagDescriptions.json
+++ b/web-data/html/mdnTagDescriptions.json
@@ -756,11 +756,7 @@
       },
       {
         "name": "importance",
-        "description": "Indicates the relative importance of the resource. Priority hints are delegated using the values:"
-      },
-      {
-        "name": "importance",
-        "description": "`auto`: Indicates **no preference**. The browser may use its own heuristics to decide the priority of the image.\n\n`high`: Indicates to the browser that the image is of **high** priority.\n\n`low`: Indicates to the browser that the image is of **low** priority."
+        "description": "Indicates the relative importance of the resource. Priority hints are delegated using the values:\n\n`auto`: Indicates **no preference**. The browser may use its own heuristics to decide the priority of the image.\n\n`high`: Indicates to the browser that the image is of **high** priority.\n\n`low`: Indicates to the browser that the image is of **low** priority."
       },
       {
         "name": "intrinsicsize",


### PR DESCRIPTION
I was using the data from `web-data/data/browsers.html-data.json` when I noticed that the img tag has two entries for the importance attribute.
```
{
  "name": "importance",
  "description": "Indicates the relative importance of the resource. Priority hints are delegated using the values:"
},
{
  "name": "importance",
  "description": "`auto`: Indicates **no preference**. The browser may use its own heuristics to decide the priority of the image.\n\n`high`: Indicates to the browser that the image is of **high** priority.\n\n`low`: Indicates to the browser that the image is of **low** priority."
},
```
I joined them with `\n\n`